### PR TITLE
Add basic CI using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: xenial
+language: python
+cache: pip
+env:
+- TEST_CMD="python -m pytest test -v --cov=pegen --cov-report term"
+install:
+- pip install pytest
+- pip install pytest-cov
+- pip install coveralls
+script:
+- $TEST_CMD
+after_success:
+- coveralls
+notifications:
+  on_success: change
+  on_failure: always
+matrix:
+  include:
+    - name: "3.8-dev"
+      python: 3.8-dev


### PR DESCRIPTION
To have a minimal continuous integration workflow, add a TravisCI
yaml file that test the package with pytest under Python 3.8 dev
with coverage. As the project evolves, this file can be extended
to run other checks such as mypy or linting.

* I did not add mypy because it still does not suport PEP572.
* I did not add any linting because I don't know if it makes sense to stick to
some style at this point. We can add a very basic one for pep8 if you want.

⚠️ Important ⚠️  To activate travis on this repo, you need to register your repo in https://travis-ci.org/account/repositories (only you can do it as the owner of the repo). Find the repo in the list and click the dial, that should be enough to activate the CI. 