### PR TITLE
Finish making pegen/ mypy-clean (and a few more cleanups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ pegen/parse
 pegen/parse.c
 
 **/__pycache__
+
+.dmypy.json

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+files = pegen, story*
+follow_imports = error
+disallow_any_generics = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,5 @@
 files = pegen, story*
 follow_imports = error
 disallow_any_generics = true
+warn_unused_ignores = true
+warn_redundant_casts = true

--- a/parse.py
+++ b/parse.py
@@ -6,7 +6,7 @@ import ast
 import sys
 import tokenize
 
-from pegen import memoize, memoize_left_rec, Parser
+from pegen.parser import memoize, memoize_left_rec, Parser
 
 
 class GeneratedParser(Parser):
@@ -1564,5 +1564,5 @@ class GeneratedParser(Parser):
 
 
 if __name__ == '__main__':
-    from pegen import simple_parser_main
+    from pegen.parser import simple_parser_main
     simple_parser_main(GeneratedParser)

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -134,8 +134,7 @@ def main() -> None:
             print()
         print("Caches sizes:")
         print(f"  token array : {len(tokenizer._tokens):10}")
-        print(f"  symbol cache: {len(parser._symbol_cache):10}")
-        print(f"  token cache : {len(parser._token_cache):10}")
+        print(f"        cache : {len(parser._cache):10}")
         if not print_memstats():
             print("(Can't find psutil; install it for memory stats.)")
 

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -7,7 +7,7 @@ import time
 import token
 import tokenize
 import traceback
-from typing import AbstractSet, Any, Callable, Dict, Generic, Iterable, List, Optional, Set, Tuple, TYPE_CHECKING, TypeVar, Union
+from typing import AbstractSet, Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TYPE_CHECKING, TypeVar, Union
 
 from pegen.parser import memoize, Parser
 from pegen.tokenizer import exact_token_types
@@ -682,7 +682,7 @@ Plain = Union[Leaf, Group]
 Item = Union[Plain, Opt, Repeat]
 
 
-class GrammarParser(Parser[Any]):
+class GrammarParser(Parser):
     """Hand-written parser for Grammar files."""
 
     @memoize

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -679,7 +679,7 @@ class Group:
 
 
 Plain = Union[Leaf, Group]
-Item = Union[Plain, Opt, Repeat]
+Item = Union[Plain, Opt, Repeat, Lookahead]
 
 
 class GrammarParser(Parser):
@@ -804,13 +804,14 @@ class GrammarParser(Parser):
         return NamedItem(None, item)
 
     @memoize
-    def lookahead(self) -> Optional[NamedItem]:
+    def lookahead(self) -> Optional[Lookahead]:
         """
         lookahead: ('&' | '!') atom
         """
         mark = self.mark()
         if (lookahead := (self.expect('&') or self.expect('!'))) and (atom := self.atom()):
             assert lookahead
+            assert atom
             if lookahead.string == '&':
                 return PositiveLookahead(atom)
             else:

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -191,12 +191,15 @@ class Leaf:
     def __str__(self):
         return self.value
 
+    @abstractmethod
     def visit(self, rules: Dict[str, Rule]) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
     def initial_names(self) -> AbstractSet[str]:
         raise NotImplementedError
 
+    @abstractmethod
     def make_call(self, gen: ParserGenerator, cpython: bool) -> Tuple[Optional[str], str]:
         raise NotImplementedError
 
@@ -540,6 +543,7 @@ class Lookahead:
     def initial_names(self) -> AbstractSet[str]:
         return set()
 
+    @abstractmethod
     def make_call(self, gen: ParserGenerator, cpython: bool) -> Tuple[Optional[str], str]:
         raise NotImplementedError
 
@@ -611,9 +615,11 @@ class Repeat:
         self.node = node
         self.memo: Optional[Tuple[Optional[str], str]] = None
 
+    @abstractmethod
     def visit(self, rules: Dict[str, Rule]) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
     def make_call(self, gen: ParserGenerator, cpython: bool) -> Tuple[Optional[str], str]:
         raise NotImplementedError
 

--- a/pegen/parser.py
+++ b/pegen/parser.py
@@ -14,13 +14,14 @@ from pegen.tokenizer import Mark
 from pegen.tokenizer import Tokenizer
 
 T = TypeVar('T')
+P = TypeVar('P', bound='Parser')
 
 
-def memoize(method: Callable[[Parser], T]) -> Callable[[Parser], T]:
+def memoize(method: Callable[[P], T]) -> Callable[[P], T]:
     """Memoize a symbol method."""
     method_name = method.__name__
 
-    def symbol_wrapper(self: Parser) -> T:
+    def symbol_wrapper(self: P) -> T:
         mark = self.mark()
         key = mark, method_name
         # Fast path: cache hit, and not verbose.
@@ -52,11 +53,11 @@ def memoize(method: Callable[[Parser], T]) -> Callable[[Parser], T]:
     return symbol_wrapper
 
 
-def memoize_left_rec(method: Callable[[Parser], Optional[T]]) -> Callable[[Parser], Optional[T]]:
+def memoize_left_rec(method: Callable[[P], Optional[T]]) -> Callable[[P], Optional[T]]:
     """Memoize a left-recursive symbol method."""
     method_name = method.__name__
 
-    def left_rec_symbol_wrapper(self: Parser) -> Optional[T]:
+    def left_rec_symbol_wrapper(self: P) -> Optional[T]:
         mark = self.mark()
         key = mark, method_name
         # Fast path: cache hit, and not verbose.
@@ -127,10 +128,10 @@ def memoize_left_rec(method: Callable[[Parser], Optional[T]]) -> Callable[[Parse
     return left_rec_symbol_wrapper
 
 
-def memoize_expect(method: Callable[[Parser, str], T]) -> Callable[[Parser, str], T]:
+def memoize_expect(method: Callable[[P, str], T]) -> Callable[[P, str], T]:
     """Memoize the expect() method."""
 
-    def expect_wrapper(self: Parser, type: str) -> T:
+    def expect_wrapper(self: P, type: str) -> T:
         mark = self.mark()
         key = mark, type
         # Fast path: cache hit.

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -19,13 +19,13 @@ import ast
 import sys
 import tokenize
 
-from pegen import memoize, memoize_left_rec, Parser
+from pegen.parser import memoize, memoize_left_rec, Parser
 
 """
 MODULE_SUFFIX = """
 
 if __name__ == '__main__':
-    from pegen import simple_parser_main
+    from pegen.parser import simple_parser_main
     simple_parser_main(GeneratedParser)
 """
 EXTENSION_PREFIX = """\


### PR DESCRIPTION
This was done in a bit of haste, so there may be some issues.

@pablogsal I'm not merging this so as not to cause you more merge grief with #7.

I also cleaned up a few things, e.g. `from pegen import` should be `from pegen.parser.import` in a few cases. (Also `__init__.py` should be empty, but I didn't do that.)

**NOTE:** This requires a non-master version of mypy, https://github.com/python/mypy/pull/6899. Because of a bug there, whenever there's code of the form
```py
if foo := self.foo():
    some_call(foo)
```
where `self.foo()` returns `Optional[X]` but `some_call()` requires plain `X`, I had to add
```py
    assert foo
```
before the call. These should be taken out once that bug is fixed. (Ideally I should have marked them with `# XXX` or something, but I thought of that too late.)
