### PR TITLE
Add a --compile-extension command to build generated C extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,24 @@
 TOP = /usr/local
 PYTHON = $(TOP)/bin/python3.8
-INCLUDES = -I$(TOP)/include/python3.8
-LDFLAGS = -L$(TOP)/lib/python3.8/config-3.8-darwin -ldl
-LDSHARED = $(CC) -bundle -undefined dynamic_lookup $(LDFLAGS)
-CFLAGS = -Werror
 
 GRAMMAR = data/cprog.gram
 TESTFILE = data/cprog.txt
 TIMEFILE = data/xxl.txt
 
-pegen/parse.so: pegen/parse.o pegen/pegen.o
-	$(LDSHARED) pegen/parse.o pegen/pegen.o -o pegen/parse.so
-
-pegen/parse.o: pegen/parse.c pegen/pegen.h pegen/v38tokenizer.h
-	$(CC) $(CFLAGS) -c $(INCLUDES) pegen/parse.c -o pegen/parse.o
-
-pegen/pegen.o: pegen/pegen.c pegen/pegen.h
-	$(CC) $(CFLAGS) -c $(INCLUDES) pegen/pegen.c -o pegen/pegen.o
-
 pegen/parse.c: $(GRAMMAR) pegen/*.py
-	$(PYTHON) -m pegen -q -c $(GRAMMAR) -o pegen/parse.c
+	$(PYTHON) -m pegen -q -c $(GRAMMAR) -o pegen/parse.c --compile-extension
 
 clean:
 	-rm -f pegen/*.o pegen/*.so pegen/parse.c
 
-dump: pegen/parse.so
+dump: pegen/parse.c
 	cat -n $(TESTFILE)
 	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse('$(TESTFILE)'); print(ast.dump(t))"
 
-test: pegen/parse.so
+test: pegen/parse.c
 	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse('$(TESTFILE)'); exec(compile(t, '', 'exec'))"
 
-time: pegen/parse.so
+time: pegen/parse.c
 	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse('$(TIMEFILE)')"
 
 time_stdlib:

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -106,7 +106,7 @@ def main() -> None:
         gen.generate(args.filename)
 
     if args.cpython and args.compile_extension:
-        compile_c_extension(output)
+        compile_c_extension(output, verbose=args.verbose)
 
     if args.verbose:
         print("First Graph:")

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -8,28 +8,21 @@ Search the web for PEG Parsers for reference.
 from __future__ import annotations  # Requires Python 3.7 or later
 
 import argparse
-import pathlib
-import shutil
 import sys
 import time
 import token
 import tokenize
 import traceback
 
-from distutils.core import Distribution, Extension
-from distutils.command.clean import clean
-from distutils.command.build_ext import build_ext
-
 from typing import Final
 
+from pegen.build import compile_c_extension
 from pegen.parser_generator import ParserGenerator
 from pegen.python_generator import PythonParserGenerator
 from pegen.c_generator import CParserGenerator
 from pegen.tokenizer import Tokenizer
 from pegen.tokenizer import grammar_tokenizer
 from pegen.grammar import GrammarParser
-
-MOD_DIR = pathlib.Path(__file__)
 
 def print_memstats() -> bool:
     MiB: Final = 2 ** 20
@@ -113,24 +106,7 @@ def main() -> None:
         gen.generate(args.filename)
 
     if args.cpython and args.compile_extension:
-        source_file_path = pathlib.Path(output)
-        extension_name = source_file_path.stem
-        extension = [Extension(extension_name,
-                     sources=[str(MOD_DIR.parent / "pegen.c"), output],
-                     include_dirs=[str(MOD_DIR.parent)],
-                     extra_compile_args=[],)]
-        dist = Distribution({'name': extension_name, 'ext_modules': extension})
-        cmd = build_ext(dist)
-        cmd.inplace = True
-        cmd.ensure_finalized()
-        cmd.run()
-        shutil.move(cmd.get_ext_fullpath(extension_name),
-                    source_file_path.parent / cmd.get_ext_filename(extension_name))
-
-        cmd = clean(dist)
-        cmd.finalize_options()
-        cmd.run()
-
+        compile_c_extension(output)
 
     if args.verbose:
         print("First Graph:")

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -1,0 +1,33 @@
+import pathlib
+import shutil
+
+from distutils.core import Distribution, Extension
+from distutils.command.clean import clean
+from distutils.command.build_ext import build_ext
+
+MOD_DIR = pathlib.Path(__file__)
+
+
+def compile_c_extension(output, build_dir=None):
+    source_file_path = pathlib.Path(output)
+    extension_name = source_file_path.stem
+    extension = [Extension(extension_name,
+                           sources=[str(MOD_DIR.parent / "pegen.c"), output],
+                           include_dirs=[str(MOD_DIR.parent)],
+                           extra_compile_args=[], )]
+    dist = Distribution({'name': extension_name, 'ext_modules': extension})
+    cmd = build_ext(dist)
+    cmd.inplace = True
+    if build_dir:
+        cmd.build_temp = build_dir
+    cmd.ensure_finalized()
+    cmd.run()
+
+    extension_path = source_file_path.parent / cmd.get_ext_filename(extension_name)
+    shutil.move(cmd.get_ext_fullpath(extension_name), extension_path)
+
+    cmd = clean(dist)
+    cmd.finalize_options()
+    cmd.run()
+
+    return extension_path

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -8,11 +8,21 @@ from distutils.command.build_ext import build_ext
 MOD_DIR = pathlib.Path(__file__)
 
 
-def compile_c_extension(output, build_dir=None):
-    source_file_path = pathlib.Path(output)
+def compile_c_extension(generated_source_path, build_dir=None):
+    """Compile the generated source for a parser generator into an extension module.
+
+    The extension module will be generated in the same directory as the provided path
+    for the generated source, with the same basename (in addition to extension module
+    metadata). For example, for the source mydir/parser.c the generated extension
+    in a darwin system with python 3.8 will be mydir/parser.cpython-38-darwin.so.
+
+    If *build_dir* is provided, that path will be used as the temporary build directory
+    of distutils (this is useful in case you want to use a temporary directory).
+    """
+    source_file_path = pathlib.Path(generated_source_path)
     extension_name = source_file_path.stem
     extension = [Extension(extension_name,
-                           sources=[str(MOD_DIR.parent / "pegen.c"), output],
+                           sources=[str(MOD_DIR.parent / "pegen.c"), generated_source_path],
                            include_dirs=[str(MOD_DIR.parent)],
                            extra_compile_args=[], )]
     dist = Distribution({'name': extension_name, 'ext_modules': extension})

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
 
+import distutils.log
 from distutils.core import Distribution, Extension
 from distutils.command.clean import clean
 from distutils.command.build_ext import build_ext
@@ -8,7 +9,7 @@ from distutils.command.build_ext import build_ext
 MOD_DIR = pathlib.Path(__file__)
 
 
-def compile_c_extension(generated_source_path, build_dir=None):
+def compile_c_extension(generated_source_path, build_dir=None, verbose=False):
     """Compile the generated source for a parser generator into an extension module.
 
     The extension module will be generated in the same directory as the provided path
@@ -19,6 +20,9 @@ def compile_c_extension(generated_source_path, build_dir=None):
     If *build_dir* is provided, that path will be used as the temporary build directory
     of distutils (this is useful in case you want to use a temporary directory).
     """
+    if verbose:
+        distutils.log.set_verbosity(distutils.log.DEBUG)
+
     source_file_path = pathlib.Path(generated_source_path)
     extension_name = source_file_path.stem
     extension = [Extension(extension_name,


### PR DESCRIPTION
To allow building the generated extesion when using the --cpython
command, add a --compile-extension command that automatically generates
an extension module (shared object). In this way, we can also build the
extensions easily on other platforms (like Linux).