### PR TITLE
Run mypy in the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 - pip install pytest
 - pip install pytest-cov
 - pip install coveralls
+- pip install git+https://github.com/python/mypy.git@refs/pull/6899/head
 script:
 - $TEST_CMD
 after_success:
@@ -18,3 +19,8 @@ matrix:
   include:
     - name: "3.8-dev"
       python: 3.8-dev
+    - name: "mypy"
+      python: 3.8-dev
+      env:
+          - TEST_CMD="mypy pegen"
+


### PR DESCRIPTION
Note
----

Mypy does still not support PEP 572 in the master branch, but to avoid
pushing code that breaks mypy check, we can still run mypy in the test
suite by installing the PR branch where PEP 572 support is being added.

Once it lands, we can switch to install the master branch or the latest
version once is released.