### PR TITLE
Ignore the types from distutils.command until they are added to typeshed

### DIFF
--- a/pegen/build.py
+++ b/pegen/build.py
@@ -3,8 +3,8 @@ import shutil
 
 import distutils.log
 from distutils.core import Distribution, Extension
-from distutils.command.clean import clean
-from distutils.command.build_ext import build_ext
+from distutils.command.clean import clean # type: ignore
+from distutils.command.build_ext import build_ext # type: ignore
 
 MOD_DIR = pathlib.Path(__file__)
 

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -3,8 +3,8 @@ import shutil
 
 import distutils.log
 from distutils.core import Distribution, Extension
-from distutils.command.clean import clean # type: ignore
-from distutils.command.build_ext import build_ext # type: ignore
+from distutils.command.clean import clean  # type: ignore
+from distutils.command.build_ext import build_ext  # type: ignore
 
 MOD_DIR = pathlib.Path(__file__)
 


### PR DESCRIPTION
Currently the mypy build is failing because the typeshed information for
distutils.command is empty:

https://github.com/python/typeshed/blob/master/stdlib/2and3/distutils/command/clean.pyi

Before this is address upstream, type ignore the imports from distutils
to fix the mypy build.