### PR TITLE
Add makefile targets as tests in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,10 @@ matrix:
       env:
           - TEST_CMD="mypy pegen"
 
+    - name: "makefile_targets"
+      python: 3.8-dev
+      env:
+          - PYTHON="python"
+      script:
+          - make dump
+          - make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOP = /usr/local
-PYTHON = $(TOP)/bin/python3.8
+PYTHON ?= $(TOP)/bin/python3.8
 
 GRAMMAR = data/cprog.gram
 TESTFILE = data/cprog.txt

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -3,8 +3,8 @@ import shutil
 
 import distutils.log
 from distutils.core import Distribution, Extension
-from distutils.command.clean import clean
-from distutils.command.build_ext import build_ext
+from distutils.command.clean import clean # type: ignore
+from distutils.command.build_ext import build_ext # type: ignore
 
 MOD_DIR = pathlib.Path(__file__)
 


### PR DESCRIPTION
Not sure if this is something we want for an extended period of time, but I though it may be useful to check that nothing breaks the makefile targets meanwhile we extend the test suite.