### PR TITLE
Add some improvements to the C generated parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,17 @@ clean:
 
 dump: pegen/parse.c
 	cat -n $(TESTFILE)
-	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse('$(TESTFILE)'); print(ast.dump(t))"
+	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse_file('$(TESTFILE)'); print(ast.dump(t))"
+
+# Note: These targets really depend on the generated shared object in pegen/parse.*.so but
+# this has different names in different systems so we are abusing the implicit dependency on
+# parse.c by the use of --compile-extension.
 
 test: pegen/parse.c
-	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse('$(TESTFILE)'); exec(compile(t, '', 'exec'))"
+	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)'); exec(compile(t, '', 'exec'))"
 
 time: pegen/parse.c
-	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse('$(TIMEFILE)')"
+	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse_file('$(TIMEFILE)')"
 
 time_stdlib:
 	/usr/bin/time -l $(PYTHON) -c "import ast; ast.parse(open('$(TIMEFILE)').read())"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GRAMMAR = data/cprog.gram
 TESTFILE = data/cprog.txt
 TIMEFILE = data/xxl.txt
 
-pegen/parse.c: $(GRAMMAR) pegen/*.py
+pegen/parse.c: $(GRAMMAR) pegen/*.py pegen/pegen.c pegen/*.h
 	$(PYTHON) -m pegen -q -c $(GRAMMAR) -o pegen/parse.c --compile-extension
 
 clean:

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -35,8 +35,6 @@ parse_string(PyObject *self, PyObject *args)
     return run_parser_from_string(the_string, (void *)start_rule, %(mode)s);
 }
 
-
-
 static PyMethodDef ParseMethods[] = {
     {"parse_file",  parse_file, METH_VARARGS, "Parse a file."},
     {"parse_string",  parse_string, METH_VARARGS, "Parse a string."},

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -22,11 +22,24 @@ parse_file(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "s", &filename))
         return NULL;
-    return run_parser(filename, (void *)start_rule, %(mode)s);
+    return run_parser_from_file(filename, (void *)start_rule, %(mode)s);
 }
 
+static PyObject *
+parse_string(PyObject *self, PyObject *args)
+{
+    const char *the_string;
+
+    if (!PyArg_ParseTuple(args, "s", &the_string))
+        return NULL;
+    return run_parser_from_string(the_string, (void *)start_rule, %(mode)s);
+}
+
+
+
 static PyMethodDef ParseMethods[] = {
-    {"parse",  parse_file, METH_VARARGS, "Parse a file."},
+    {"parse_file",  parse_file, METH_VARARGS, "Parse a file."},
+    {"parse_string",  parse_string, METH_VARARGS, "Parse a string."},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -50,5 +50,6 @@ void *CONSTRUCTOR(Parser *p, ...);
 #define ENDCOL(arg) ((expr_ty)(arg))->end_col_offset
 #define EXTRA(head, tail) LINE(head), COL(head), ENDLINE(tail), ENDCOL(tail), p->arena
 
-PyObject *run_parser(const char *filename, void *(start_rule_func)(Parser *), int mode);
+PyObject *run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode);
+PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int mode);
 asdl_seq *singleton_seq(Parser *, void *);

--- a/test/test_pegen.py
+++ b/test/test_pegen.py
@@ -75,22 +75,7 @@ def generate_parser_c_extension(rules, path):
     return extension
 
 
-@pytest.mark.parametrize(
-    "expr",
-    [
-        "4+5",
-        "4-5",
-        "4*5",
-        "1+4*5",
-        "1+4/5",
-        "(1+1) + (1+1)",
-        "(1+1) - (1+1)",
-        "(1+1) * (1+1)",
-        "(1+1) / (1+1)",
-    ]
-
-)
-def test_c_parser(expr, tmp_path):
+def test_c_parser(tmp_path):
     grammar = """
     start[mod_ty]: a=stmt* $ { Module(a, NULL, p->arena) }
     stmt[stmt_ty]: a=expr_stmt { a }
@@ -114,13 +99,22 @@ def test_c_parser(expr, tmp_path):
     rules = parse_string(grammar, GrammarParser).rules
     extension = generate_parser_c_extension(rules, tmp_path)
 
-    parse_file = tmp_path / "cprog.txt"
-    with open(parse_file, "w") as file:
-        file.write(expr)
+    expressions = [
+        "4+5",
+        "4-5",
+        "4*5",
+        "1+4*5",
+        "1+4/5",
+        "(1+1) + (1+1)",
+        "(1+1) - (1+1)",
+        "(1+1) * (1+1)",
+        "(1+1) / (1+1)",
+    ]
 
-    the_ast = extension.parse(str(parse_file))
-    expected_ast = ast.parse(expr)
-    assert ast.dump(the_ast) == ast.dump(expected_ast)
+    for expr in expressions:
+        the_ast = extension.parse_string(expr)
+        expected_ast = ast.parse(expr)
+        assert ast.dump(the_ast) == ast.dump(expected_ast)
 
 
 def test_parse_grammar():


### PR DESCRIPTION
* Add a function to allow the parser to parse python strings directly.
* Add free code to the run_parser function and new specialized functions.
* Make the Makefile default target depend on pegen.c and headers (so it regenerates when editing them).
* Speed up the c parser test by generating the extension only once.
* Move to use the Python allocator to make it easier to trace stuff in the future.