### PR TITLE
Add build badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 PEG parser generator
 ====================
+[![Build Status](https://travis-ci.com/gvanrossum/pegen.svg?branch=master)](https://travis-ci.com/gvanrossum/pegen)
 
 This is a work in progress.  Right now it can read a grammar (using an
 extension of the notation used by pgen2 for CPython's Grammar) and


### PR DESCRIPTION
One last change for today!

In order to have always an easy way to know if something is wrong with
the CI pipeline, add a build status badge to the readme so the last
build status is always visible from the main page of the project.

I have also configured Travis to run once a day (in addition to new commits and PRs).

You can see how the badge looks here:

https://github.com/pablogsal/pegen/blob/badge/README.md