### PR TITLE
Allow passing a grammar file path to the directory test script to regenerate the parser 

### DIFF
--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -71,14 +71,18 @@ def main() -> None:
         else:
             output_file = "parse.py"
 
-    rules, parser, tokenizer, gen = build_parser(
-        args.filename,
-        output_file,
-        args.compile_extension,
-        verbose_tokenizer,
-        verbose_parser,
-        args.verbose,
-    )
+    try:
+        rules, parser, tokenizer, gen = build_parser(
+            args.filename,
+            output_file,
+            args.compile_extension,
+            verbose_tokenizer,
+            verbose_parser,
+            args.verbose,
+        )
+    except Exception as err:
+        traceback.print_exception(err.__class__, err, None)
+        sys.exit(1)
 
     if not args.quiet:
         if args.verbose:

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -77,6 +77,7 @@ def main() -> None:
         args.compile_extension,
         verbose_tokenizer,
         verbose_parser,
+        args.verbose,
     )
 
     if not args.quiet:

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 import time
 import token
+import traceback
 
 from typing import Final
 

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -90,13 +90,13 @@ def build_parser(
         gen: ParserGenerator
         if output_file.endswith(".c"):
             gen = CParserGenerator(rules.rules, file)
+
+            if compile_extension:
+                compile_c_extension(output_file, verbose=verbose_c_extension)
         elif output_file.endswith(".py"):
             gen = PythonParserGenerator(rules.rules, file)
         else:
             raise Exception("Your output file must either be a .c or .py file")
         gen.generate(grammar_file)
-
-    if compile_extension:
-        compile_c_extension(output_file, verbose=verbose_c_extension)
 
     return rules, parser, tokenizer, gen

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -61,19 +61,20 @@ def build_parser(
     verbose_parser=False,
     verbose_c_extension=False,
 ):
-    """[summary]
+   """Generate rules, parser, tokenizer, parser generator for a given grammar
 
-    Args:
-        grammar_file ([type]): [description]
-        output_file ([type]): [description]
-        compile_extension (bool, optional): [description]. Defaults to False.
-
-    Raises:
-        parser.make_syntax_error: [description]
-
-    Returns:
-        [type]: [description]
-    """
+   Args:
+       grammar_file (string): Path for the grammar file
+       output_file (string): Path for the output file
+       compile_extension (bool, optional): Whether to compile the C extension.
+         Defaults to False.
+       verbose_tokenizer (bool, optional): Whether to display additional output
+         when generating the tokenizer. Defaults to False.
+       verbose_parser (bool, optional): Whether to display additional output
+         when generating the parser. Defaults to False.
+       verbose_c_extension (bool, optional): Whether to display additional
+         output when compiling the C extension . Defaults to False.
+   """
     with open(grammar_file) as file:
         tokenizer = Tokenizer(
             grammar_tokenizer(tokenize.generate_tokens(file.readline)),

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -1,10 +1,16 @@
 import pathlib
 import shutil
+import tokenize
 
 import distutils.log
 from distutils.core import Distribution, Extension
 from distutils.command.clean import clean  # type: ignore
 from distutils.command.build_ext import build_ext  # type: ignore
+
+from pegen.c_generator import CParserGenerator
+from pegen.tokenizer import Tokenizer
+from pegen.tokenizer import grammar_tokenizer
+from pegen.grammar import GrammarParser
 
 MOD_DIR = pathlib.Path(__file__)
 
@@ -45,3 +51,50 @@ def compile_c_extension(generated_source_path, build_dir=None, verbose=False):
     cmd.run()
 
     return extension_path
+
+
+def build_parser(
+    grammar_file,
+    output_file,
+    compile_extension=False,
+    verbose_tokenizer=False,
+    verbose_parser=False,
+):
+    """[summary]
+
+    Args:
+        grammar_file ([type]): [description]
+        output_file ([type]): [description]
+        compile_extension (bool, optional): [description]. Defaults to False.
+
+    Raises:
+        parser.make_syntax_error: [description]
+
+    Returns:
+        [type]: [description]
+    """
+    with open(grammar_file) as file:
+        tokenizer = Tokenizer(
+            grammar_tokenizer(tokenize.generate_tokens(file.readline)),
+            verbose=verbose_tokenizer,
+        )
+        parser = GrammarParser(tokenizer, verbose=verbose_parser)
+        rules = parser.start()
+
+        if not rules:
+            raise parser.make_syntax_error(grammar_file)
+
+    with open(output_file, "w") as file:
+        gen: ParserGenerator
+        if output_file.endswith(".c"):
+            gen = CParserGenerator(rules.rules, file)
+        elif output_file.endswith(".py"):
+            gen = PythonParserGenerator(rules.rules, file)
+        else:
+            raise Exception("Your output file must either be a .c or .py file")
+        gen.generate(grammar_file)
+
+    if compile_extension:
+        compile_c_extension(output_file)
+
+    return rules, parser, tokenizer, gen

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -90,13 +90,13 @@ def build_parser(
         gen: ParserGenerator
         if output_file.endswith(".c"):
             gen = CParserGenerator(rules.rules, file)
-
-            if compile_extension:
-                compile_c_extension(output_file, verbose=verbose_c_extension)
         elif output_file.endswith(".py"):
             gen = PythonParserGenerator(rules.rules, file)
         else:
             raise Exception("Your output file must either be a .c or .py file")
         gen.generate(grammar_file)
+
+    if compile_extension and output_file.endswith(".c"):
+        compile_c_extension(output_file, verbose=verbose_c_extension)
 
     return rules, parser, tokenizer, gen

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -61,20 +61,20 @@ def build_parser(
     verbose_parser=False,
     verbose_c_extension=False,
 ):
-   """Generate rules, parser, tokenizer, parser generator for a given grammar
+    """Generate rules, parser, tokenizer, parser generator for a given grammar
 
-   Args:
-       grammar_file (string): Path for the grammar file
-       output_file (string): Path for the output file
-       compile_extension (bool, optional): Whether to compile the C extension.
-         Defaults to False.
-       verbose_tokenizer (bool, optional): Whether to display additional output
-         when generating the tokenizer. Defaults to False.
-       verbose_parser (bool, optional): Whether to display additional output
-         when generating the parser. Defaults to False.
-       verbose_c_extension (bool, optional): Whether to display additional
-         output when compiling the C extension . Defaults to False.
-   """
+    Args:
+        grammar_file (string): Path for the grammar file
+        output_file (string): Path for the output file
+        compile_extension (bool, optional): Whether to compile the C extension.
+          Defaults to False.
+        verbose_tokenizer (bool, optional): Whether to display additional output
+          when generating the tokenizer. Defaults to False.
+        verbose_parser (bool, optional): Whether to display additional output
+          when generating the parser. Defaults to False.
+        verbose_c_extension (bool, optional): Whether to display additional
+          output when compiling the C extension . Defaults to False.
+    """
     with open(grammar_file) as file:
         tokenizer = Tokenizer(
             grammar_tokenizer(tokenize.generate_tokens(file.readline)),

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -59,6 +59,7 @@ def build_parser(
     compile_extension=False,
     verbose_tokenizer=False,
     verbose_parser=False,
+    verbose_c_extension=False,
 ):
     """[summary]
 
@@ -95,6 +96,6 @@ def build_parser(
         gen.generate(grammar_file)
 
     if compile_extension:
-        compile_c_extension(output_file)
+        compile_c_extension(output_file, verbose=verbose_c_extension)
 
     return rules, parser, tokenizer, gen

--- a/test_parse_directory.py
+++ b/test_parse_directory.py
@@ -71,7 +71,7 @@ def main():
         from pegen import parse
     except:
         print(
-            f"An existing parser was not found. Please run `make` or specify a grammar file with the `-g` flag."
+            "An existing parser was not found. Please run `make` or specify a grammar file with the `-g` flag."
         )
         sys.exit(1)
 


### PR DESCRIPTION
- Add a helper function for generating the parser, with error handling if an error occurs
- Add a grammar file arg
- Update `sys.exit` calls to supply error code
- Refactor parser generation into a helper function. Update pegen/__main__.py and test_parse_directory.py to use the new helper
- Remove `endpos`