### PR TITLE
Finish cut (~) implementation

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -159,6 +159,6 @@ target: atom t_tail+ | t_atom t_tail*
 t_atom: NAME | '(' [targets] ')' | '[' [targets] ']'
 
 t_tail: call_tail* (attr_tail | index_tail)
-call_tail: '(' [arguments] ')'
+call_tail: '(' ~ [arguments] ')'
 attr_tail: '.' NAME
-index_tail: '[' slices ']'
+index_tail: '[' ~ slices ']'

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -86,7 +86,7 @@ class CCallMakerVisitor(GrammarVisitor):
 
     def visit_NameLeaf(self, node: NameLeaf) -> Tuple[str, str]:
         name = node.value
-        if name in ("NAME", "NUMBER", "STRING", "CUT", "CURLY_STUFF"):
+        if name in ("NAME", "NUMBER", "STRING", "CURLY_STUFF"):
             name = name.lower()
             return f"{name}_var", f"{name}_token(p)"
         if name in ("NEWLINE", "DEDENT", "INDENT", "ENDMARKER", "ASYNC", "AWAIT"):
@@ -323,8 +323,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         if not name:
             self.print(call)
         else:
-            if name != "cut":
-                name = dedupe(name, names)
+            name = dedupe(name, names)
             self.print(f"({name} = {call})")
 
     def visit_Rhs(self, node: Rhs, is_loop: bool, rulename: Optional[str]) -> None:
@@ -338,6 +337,8 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 type = "void *"
             else:
                 type += " "
+            if v == "cut_var":
+                v += " = 0"  # cut_var must be initialized
             self.print(f"{type}{v};")
         for alt in node.alts:
             self.visit(alt, is_loop=is_loop, rulename=rulename)

--- a/pegen/parser.py
+++ b/pegen/parser.py
@@ -176,12 +176,6 @@ class Parser:
         tok = self._tokenizer.peek()
         return f"{tok.start[0]}.{tok.start[1]}: {token.tok_name[tok.type]}:{tok.string!r}"
 
-    def cut(self) -> bool:
-        if self._verbose:
-            fill = "  " * self._level
-            print(f"{fill}CUT ... (looking at {self.showpeek()})")
-        return True
-
     @memoize
     def name(self) -> Optional[tokenize.TokenInfo]:
         tok = self._tokenizer.peek()

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -17,7 +17,6 @@ class RuleCheckingVisitor(GrammarVisitor):
         if (
             node.value not in self.rules
             and node.value not in token.tok_name.values()
-            and node.value != "CUT"
         ):
             # TODO: Add line/col info to (leaf) nodes
             raise GrammarError(f"Dangling reference to rule {node.value!r}")

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -153,11 +153,6 @@ lookahead(int positive, void *(func)(Parser *), Parser *p)
     return (res != NULL) == positive;
 }
 
-int cut_token(Parser *p)
-{
-    return 1;
-}
-
 Token *
 expect_token(Parser *p, int type)
 {

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -35,7 +35,6 @@ int lookahead_with_int(int, Token *(func)(Parser *, int), Parser *, int);
 int lookahead(int, void *(func)(Parser *), Parser *);
 
 Token *expect_token(Parser *p, int type);
-int cut_token(Parser *p);
 
 void *async_token(Parser *p);
 void *await_token(Parser *p);

--- a/pegen/python_generator.py
+++ b/pegen/python_generator.py
@@ -48,7 +48,7 @@ class PythonCallMakerVisitor(GrammarVisitor):
 
     def visit_NameLeaf(self, node: NameLeaf) -> Tuple[Optional[str], str]:
         name = node.value
-        if name in ("NAME", "NUMBER", "STRING", "OP", "CUT", "CURLY_STUFF"):
+        if name in ("NAME", "NUMBER", "STRING", "OP", "CURLY_STUFF"):
             name = name.lower()
             return name, f"self.{name}()"
         if name in ("NEWLINE", "DEDENT", "INDENT", "ENDMARKER", "ASYNC", "AWAIT"):


### PR DESCRIPTION
- Remove vestiges of old implementation
- Initialize cut_var to 0
- Use cut in a few places in simpy.gram