### PR TITLE
Validate implementation of 'cut' expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOP = /usr/local
-PYTHON ?= $(TOP)/bin/python3.8
+PYTHON ?= `which python3.8`
 
 GRAMMAR = data/cprog.gram
 TESTFILE = data/cprog.txt

--- a/data/cprog.gram
+++ b/data/cprog.gram
@@ -1,14 +1,14 @@
 start[mod_ty]: a=stmt* ENDMARKER { Module(a, NULL, p->arena) }
 stmt[stmt_ty]: compound_stmt | simple_stmt
-compound_stmt[stmt_ty]: pass_stmt | if_stmt
+compound_stmt[stmt_ty]: if_stmt | pass_stmt
 
-pass_stmt[stmt_ty]: a='pass' NEWLINE { _Py_Pass(EXTRA(a, a)) }
+pass_stmt[stmt_ty]: a='pass' ~ NEWLINE { _Py_Pass(EXTRA(a, a)) }
 
 if_stmt[stmt_ty]:
     | 'if' ~ c=expr ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA(c, c)) }
 else_clause[asdl_seq*]:
-    | 'elif' c=expr ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA(c, c))) }
-    | 'else' ':' s=suite { s }
+    | 'elif' ~ c=expr ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA(c, c))) }
+    | 'else' ~ ':' s=suite { s }
 
 suite[asdl_seq*]:
     | a=simple_stmt { singleton_seq(p, a) }

--- a/data/cprog.gram
+++ b/data/cprog.gram
@@ -5,7 +5,7 @@ compound_stmt[stmt_ty]: pass_stmt | if_stmt
 pass_stmt[stmt_ty]: a='pass' NEWLINE { _Py_Pass(EXTRA(a, a)) }
 
 if_stmt[stmt_ty]:
-    | 'if' c=expr ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA(c, c)) }
+    | 'if' ~ c=expr ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA(c, c)) }
 else_clause[asdl_seq*]:
     | 'elif' c=expr ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA(c, c))) }
     | 'else' ':' s=suite { s }

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -307,7 +307,7 @@ keyword_token(Parser *p, const char *val)
 }
 
 PyObject *
-run_parser(struct tok_state* tok, void *(start_rule_func)(Parser *), int mode)
+run_parser(struct tok_state* tok, void *(start_rule_func)(Parser *, int *), int mode)
 {
     PyObject* result = NULL;
     Parser *p = PyMem_Malloc(sizeof(Parser));
@@ -338,7 +338,8 @@ run_parser(struct tok_state* tok, void *(start_rule_func)(Parser *), int mode)
 
     PyErr_Clear();
 
-    void *res = (*start_rule_func)(p);
+    int cut_var = 0;
+    void *res = (*start_rule_func)(p, &cut_var);
     if (res == NULL) {
         if (PyErr_Occurred()) {
             goto exit;
@@ -376,7 +377,7 @@ exit:
 }
 
 PyObject *
-run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode)
+run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *, int *), int mode)
 {
     FILE *fp = fopen(filename, "rb");
     if (fp == NULL) {
@@ -410,7 +411,7 @@ run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), in
 }
 
 PyObject *
-run_parser_from_string(const char* str, void *(start_rule_func)(Parser *), int mode)
+run_parser_from_string(const char* str, void *(start_rule_func)(Parser *, int *), int mode)
 {
     struct tok_state* tok = PyTokenizer_FromString(str, 1);
 

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -55,6 +55,6 @@ void *CONSTRUCTOR(Parser *p, ...);
 #define ENDCOL(arg) ((expr_ty)(arg))->end_col_offset
 #define EXTRA(head, tail) LINE(head), COL(head), ENDLINE(tail), ENDCOL(tail), p->arena
 
-PyObject *run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode);
-PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int mode);
+PyObject *run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *, int *), int mode);
+PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser *, int *), int mode);
 asdl_seq *singleton_seq(Parser *, void *);


### PR DESCRIPTION
There needs to be a _'cut' context_ for each choice (`|`), optional (`[e]`), and closure (`e*`, `e+`), so a cut (`~`) expression will commit the most recent context at runtime.

fixes #49 