### PR TITLE
Refactor import rules to correctly generate AST for import_name

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -50,8 +50,8 @@ import_from: ('from' (('.' | '...')* !'import' dotted_name | ('.' | '...')+)
               'import' ('*' | '(' import_as_names ')' | import_as_names))
 import_as_name: NAME ['as' NAME]
 dotted_as_name[alias_ty]:
-    | a=dotted_name 'as' b=NAME { _Py_alias(get_identifier_from_expr_ty(a), get_identifier_from_expr_ty(b), p->arena) }
-    | a=dotted_name { _Py_alias(get_identifier_from_expr_ty(a), NULL, p->arena) }
+    | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
+    | a=dotted_name { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
 import_as_names: import_as_name (',' import_as_name)* [',']
 dotted_as_names[asdl_seq*]: a=dotted_as_name b=further_dotted_as_names* { seq_insert_in_front(p, a, b) }
 further_dotted_as_names[alias_ty]: ',' a=dotted_as_name { a }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -44,15 +44,19 @@ break_stmt: a='break' { _Py_Break(EXTRA(a, a)) }
 continue_stmt: a='continue' { _Py_Continue(EXTRA(a, a)) }
 
 import_stmt: import_name | import_from
-import_name: 'import' dotted_as_names
+import_name[stmt_ty]: a='import' b=dotted_as_names { _Py_Import(b, EXTRA(a, b)) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from: ('from' (('.' | '...')* !'import' dotted_name | ('.' | '...')+)
               'import' ('*' | '(' import_as_names ')' | import_as_names))
 import_as_name: NAME ['as' NAME]
-dotted_as_name: dotted_name ['as' NAME]
+dotted_as_name[alias_ty]:
+    | a=dotted_name 'as' b=NAME { _Py_alias(get_identifier_from_expr_ty(a), get_identifier_from_expr_ty(b), p->arena) }
+    | a=dotted_name { _Py_alias(get_identifier_from_expr_ty(a), NULL, p->arena) }
 import_as_names: import_as_name (',' import_as_name)* [',']
-dotted_as_names: dotted_as_name (',' dotted_as_name)*
-dotted_name: NAME ('.' NAME)*
+dotted_as_names[asdl_seq*]: a=dotted_as_name b=further_dotted_as_names* { seq_insert_in_front(p, a, b) }
+further_dotted_as_names[alias_ty]: ',' a=dotted_as_name { a }
+dotted_name[expr_ty]: a=NAME b=further_dotted_name* { seq_to_dotted_name(p, seq_insert_in_front(p, a, b)) }
+further_dotted_name[expr_ty]: '.' a=NAME { a }
 
 if_stmt:
     | 'if' a=full_expression ':' b=block c=else_block { _Py_If(a, b, c, EXTRA(a, c)) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -54,7 +54,7 @@ dotted_as_name[alias_ty]:
     | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
     | a=dotted_name { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
 dotted_name[expr_ty]:
-    | a=NAME '.' b=dotted_name { join_names_with_dot(p, a, b) }
+    | a=dotted_name '.' b=NAME { join_names_with_dot(p, a, b) }
     | NAME
 
 if_stmt:

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -54,7 +54,7 @@ dotted_as_name[alias_ty]:
     | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
     | a=dotted_name { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
 dotted_name[expr_ty]:
-    | a=NAME b=('.' c=dotted_name { c }) { join_names_with_dot(p, a, b) }
+    | a=NAME '.' b=dotted_name { join_names_with_dot(p, a, b) }
     | NAME
 
 if_stmt:

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -3,9 +3,8 @@
 start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
 statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
 
-statement[asdl_seq*]:  a=compound_stmt { singleton_seq(p, a) } | simple_stmt
-simple_stmt[asdl_seq*]: a=small_stmt b=further_small_stmt* [';'] NEWLINE { seq_insert_in_front(p, a, b) }
-further_small_stmt[stmt_ty]: ';' a=small_stmt { a }
+statement[asdl_seq*]: a=compound_stmt { singleton_seq(p, a) } | simple_stmt
+simple_stmt[asdl_seq*]: a=small_stmt b=(';' c=small_stmt { c })* [';'] NEWLINE { seq_insert_in_front(p, a, b) }
 # NOTE: assignment MUST precede expression, else the parser will get stuck;
 # but it must follow all others, else reserved words will match a simple NAME.
 small_stmt[stmt_ty]:
@@ -47,16 +46,14 @@ import_stmt: import_name | import_from
 import_name[stmt_ty]: a='import' b=dotted_as_names { _Py_Import(b, EXTRA(a, b)) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from: ('from' (('.' | '...')* !'import' dotted_name | ('.' | '...')+)
-              'import' ('*' | '(' import_as_names ')' | import_as_names))
-import_as_name: NAME ['as' NAME]
+              'import' ('*' | '(' import_from_as_names ')' | import_from_as_names))
+import_from_as_names: import_from_as_name (',' import_from_as_name)* [',']
+import_from_as_name: NAME ['as' NAME]
+dotted_as_names[asdl_seq*]: a=dotted_as_name b=(',' c=dotted_as_name { c })* { seq_insert_in_front(p, a, b) }
 dotted_as_name[alias_ty]:
     | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
     | a=dotted_name { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
-import_as_names: import_as_name (',' import_as_name)* [',']
-dotted_as_names[asdl_seq*]: a=dotted_as_name b=further_dotted_as_names* { seq_insert_in_front(p, a, b) }
-further_dotted_as_names[alias_ty]: ',' a=dotted_as_name { a }
-dotted_name[expr_ty]: a=NAME b=further_dotted_name* { seq_to_dotted_name(p, seq_insert_in_front(p, a, b)) }
-further_dotted_name[expr_ty]: '.' a=NAME { a }
+dotted_name[expr_ty]: a=NAME b=('.' c=NAME { c })* { seq_to_dotted_name(p, seq_insert_in_front(p, a, b)) }
 
 if_stmt:
     | 'if' a=full_expression ':' b=block c=else_block { _Py_If(a, b, c, EXTRA(a, c)) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -53,7 +53,9 @@ dotted_as_names[asdl_seq*]: a=dotted_as_name b=(',' c=dotted_as_name { c })* { s
 dotted_as_name[alias_ty]:
     | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
     | a=dotted_name { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
-dotted_name[expr_ty]: a=NAME b=('.' c=NAME { c })* { seq_to_dotted_name(p, seq_insert_in_front(p, a, b)) }
+dotted_name[expr_ty]:
+    | a=NAME b=('.' c=dotted_name { c }) { join_names_with_dot(p, a, b) }
+    | NAME
 
 if_stmt:
     | 'if' a=full_expression ':' b=block c=else_block { _Py_If(a, b, c, EXTRA(a, c)) }

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -514,7 +514,10 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
     expr_ty final_name = asdl_seq_GET(seq, 0);
     for (int i = 1, l = asdl_seq_LEN(seq); i < l; i++) {
         expr_ty name = asdl_seq_GET(seq, i);
-        final_name = _Py_Attribute(final_name, get_identifier_from_expr_ty(name), Load, EXTRA(final_name, name));
+        final_name = _Py_Attribute(final_name,
+                                   get_identifier_from_expr_ty(name),
+                                   Load,
+                                   EXTRA(final_name, name));
     }
 
     return final_name;

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -507,6 +507,8 @@ seq_flatten(Parser *p, asdl_seq *seqs)
 expr_ty
 seq_to_dotted_name(Parser *p, asdl_seq *seq)
 {
+    /* Create a string of the form a.b.c like Python/ast.c alias_for_dotted_name does
+       for dotted names */
     if (asdl_seq_LEN(seq) == 1) {
         return asdl_seq_GET(seq, 0);
     }
@@ -544,8 +546,9 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
                                            PyBytes_GET_SIZE(str),
                                            NULL);
     Py_DECREF(str);
-    if (!uni)
+    if (!uni) {
         return NULL;
+    }
     str = uni;
     PyUnicode_InternInPlace(&str);
     if (PyArena_AddPyObject(p->arena, str) < 0) {

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -564,16 +564,3 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
     return Name(str, Load, first_elem->lineno, first_elem->col_offset,
                 last_elem->end_lineno, last_elem->end_col_offset, p->arena);
 }
-
-identifier
-get_identifier_from_expr_ty(expr_ty expr)
-{
-    if (expr->kind == Attribute_kind) {
-        return expr->v.Attribute.attr;
-    }
-    if (expr->kind == Name_kind) {
-        return expr->v.Name.id;
-    }
-
-    return NULL;
-}

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -518,7 +518,7 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
     for (int i = 0, l = asdl_seq_LEN(seq); i < l; i++) {
         expr_ty current_expr = asdl_seq_GET(seq, i);
         ssize_t current_len = PyUnicode_GET_LENGTH(current_expr->v.Name.id);
-        len += strlen(current_len) + 1;
+        len += current_len + 1;
     }
     len--; // Last name does not have a dot
 

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -520,7 +520,7 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
         ssize_t current_len = PyUnicode_GET_LENGTH(current_expr->v.Name.id);
         len += current_len + 1;
     }
-    len--; // Last name does not have a dot
+    --len; // Last name does not have a dot
 
     PyObject *str = PyBytes_FromStringAndSize(NULL, len);
     if (!str) {
@@ -534,7 +534,10 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
 
     for (int i = 0, l = asdl_seq_LEN(seq); i < l; i++) {
         expr_ty current_expr = asdl_seq_GET(seq, i);
-        const char *current_name = PyUnicode_AS_DATA(current_expr->v.Name.id);
+        const char *current_name = PyUnicode_AsUTF8(current_expr->v.Name.id);
+        if (!current_name) {
+            return NULL;
+        }
         strcpy(s, current_name);
         s += strlen(current_name);
         *s++ = '.';

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -503,3 +503,32 @@ seq_flatten(Parser *p, asdl_seq *seqs)
 
     return flattened_seq;
 }
+
+expr_ty
+seq_to_dotted_name(Parser *p, asdl_seq *seq)
+{
+    if (!seq) {
+        return NULL;
+    }
+
+    expr_ty final_name = asdl_seq_GET(seq, 0);
+    for (int i = 1, l = asdl_seq_LEN(seq); i < l; i++) {
+        expr_ty name = asdl_seq_GET(seq, i);
+        final_name = _Py_Attribute(final_name, get_identifier_from_expr_ty(name), Load, EXTRA(final_name, name));
+    }
+
+    return final_name;
+}
+
+identifier
+get_identifier_from_expr_ty(expr_ty expr)
+{
+    if (expr->kind == Attribute_kind) {
+        return expr->v.Attribute.attr;
+    }
+    if (expr->kind == Name_kind) {
+        return expr->v.Name.id;
+    }
+
+    return NULL;
+}

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -507,8 +507,6 @@ seq_flatten(Parser *p, asdl_seq *seqs)
 expr_ty
 join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
 {
-    /* Create a string of the form "first_name.second_name" like
-       Python/ast.c alias_for_dotted_name does for dotted names */
     PyObject *first_identifier = first_name->v.Name.id;
     PyObject *second_identifier = second_name->v.Name.id;
 
@@ -518,9 +516,15 @@ join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
     if (PyUnicode_READY(second_identifier) == -1) {
         return NULL;
     }
-    ssize_t len = PyUnicode_GET_LENGTH(first_name->v.Name.id) +
-                  PyUnicode_GET_LENGTH(second_name->v.Name.id) + 1; // +1 for the dot
-
+    const char *first_str = PyUnicode_AsUTF8(first_identifier);
+    if (!first_str) {
+        return NULL;
+    }
+    const char *second_str = PyUnicode_AsUTF8(second_identifier);
+    if (!second_str) {
+        return NULL;
+    }
+    ssize_t len = strlen(first_str) + strlen(second_str) + 1; // +1 for the dot
 
     PyObject *str = PyBytes_FromStringAndSize(NULL, len);
     if (!str) {
@@ -532,14 +536,6 @@ join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
         return NULL;
     }
 
-    const char *first_str = PyUnicode_AsUTF8(first_name->v.Name.id);
-    if (!first_str) {
-        return NULL;
-    }
-    const char *second_str = PyUnicode_AsUTF8(second_name->v.Name.id);
-    if (!second_str) {
-        return NULL;
-    }
     strcpy(s, first_str);
     s += strlen(first_str);
     *s++ = '.';

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -522,7 +522,7 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
     }
     len--; // Last name does not have a dot
 
-    identifier str = PyBytes_FromStringAndSize(NULL, len);
+    PyObject *str = PyBytes_FromStringAndSize(NULL, len);
     if (!str) {
         return NULL;
     }
@@ -542,9 +542,9 @@ seq_to_dotted_name(Parser *p, asdl_seq *seq)
     s--;
     *s = '\0';
 
-    identifier *uni = PyUnicode_DecodeUTF8(PyBytes_AS_STRING(str),
-                                           PyBytes_GET_SIZE(str),
-                                           NULL);
+    PyObject *uni = PyUnicode_DecodeUTF8(PyBytes_AS_STRING(str),
+                                         PyBytes_GET_SIZE(str),
+                                         NULL);
     Py_DECREF(str);
     if (!uni) {
         return NULL;

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -60,4 +60,4 @@ PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser
 asdl_seq *singleton_seq(Parser *, void *);
 asdl_seq *seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *seq_flatten(Parser *, asdl_seq *);
-expr_ty seq_to_dotted_name(Parser *, asdl_seq *);
+expr_ty join_names_with_dot(Parser *, expr_ty, expr_ty);

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -61,4 +61,3 @@ asdl_seq *singleton_seq(Parser *, void *);
 asdl_seq *seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *seq_flatten(Parser *, asdl_seq *);
 expr_ty seq_to_dotted_name(Parser *, asdl_seq *);
-identifier get_identifier_from_expr_ty(expr_ty);

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -60,3 +60,5 @@ PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser
 asdl_seq *singleton_seq(Parser *, void *);
 asdl_seq *seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *seq_flatten(Parser *, asdl_seq *);
+expr_ty seq_to_dotted_name(Parser *, asdl_seq *);
+identifier get_identifier_from_expr_ty(expr_ty);

--- a/test/test_data/import.py
+++ b/test/test_data/import.py
@@ -1,0 +1,1 @@
+import a

--- a/test/test_data/import_alias.py
+++ b/test/test_data/import_alias.py
@@ -1,0 +1,1 @@
+import a as b

--- a/test/test_data/import_dotted.py
+++ b/test/test_data/import_dotted.py
@@ -1,0 +1,1 @@
+import a.b

--- a/test/test_data/import_dotted_alias.py
+++ b/test/test_data/import_dotted_alias.py
@@ -1,0 +1,1 @@
+import a.b as c

--- a/test/test_data/import_dotted_multichar.py
+++ b/test/test_data/import_dotted_multichar.py
@@ -1,0 +1,1 @@
+import ab.cd


### PR DESCRIPTION
This parses and generates the AST for `import_name` statements (correctly) without any segfaults. 

The only problem, which I have completely ignored until now, because I don't really know what the solution for it would be, is that a wrong AST gets generated when parsing `import a.b`, because only `b` gets identified. That has to do with the fact that the first argument to `_Py_alias` is the `attr` only, without any mention to the rest of the value. Some help would be needed here!