### PR TITLE
Refactor import rules to correctly generate AST for import_from

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -46,7 +46,8 @@ import_stmt: import_name | import_from
 import_name[stmt_ty]: a='import' b=dotted_as_names { _Py_Import(b, EXTRA(a, b)) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from[stmt_ty]:
-    | a='from' b=('.' | '...')* !'import' c=dotted_name 'import' d=import_from_targets { _Py_ImportFrom(((expr_ty) c)->v.Name.id, d, seq_count_dots(b), EXTRA(a, d)) }
+    | a='from' b=('.' | '...')* !'import' c=dotted_name 'import' d=import_from_targets {
+        _Py_ImportFrom(((expr_ty) c)->v.Name.id, d, seq_count_dots(b), EXTRA(a, d)) }
     | e='from' f=('.' | '...')+ 'import' g=import_from_targets { _Py_ImportFrom(NULL, g, seq_count_dots(f), EXTRA(e, g)) }
 import_from_targets[asdl_seq*]:
     | '(' a=import_from_as_names ')' { a }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -45,10 +45,17 @@ continue_stmt: a='continue' { _Py_Continue(EXTRA(a, a)) }
 import_stmt: import_name | import_from
 import_name[stmt_ty]: a='import' b=dotted_as_names { _Py_Import(b, EXTRA(a, b)) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
-import_from: ('from' (('.' | '...')* !'import' dotted_name | ('.' | '...')+)
-              'import' ('*' | '(' import_from_as_names ')' | import_from_as_names))
-import_from_as_names: import_from_as_name (',' import_from_as_name)* [',']
-import_from_as_name: NAME ['as' NAME]
+import_from[stmt_ty]:
+    | a='from' b=('.' | '...')* !'import' c=dotted_name 'import' d=import_from_targets { _Py_ImportFrom(((expr_ty) c)->v.Name.id, d, seq_count_dots(b), EXTRA(a, d)) }
+    | e='from' f=('.' | '...')+ 'import' g=import_from_targets { _Py_ImportFrom(NULL, g, seq_count_dots(f), EXTRA(e, g)) }
+import_from_targets[asdl_seq*]:
+    | '(' a=import_from_as_names ')' { a }
+    | import_from_as_names
+    | a='*' { singleton_seq(p, a) }
+import_from_as_names[asdl_seq*]: a=import_from_as_name b=(',' c=import_from_as_name { c })* [','] { seq_insert_in_front(p, a, b) }
+import_from_as_name[alias_ty]:
+    | a=NAME 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
+    | a=NAME { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
 dotted_as_names[asdl_seq*]: a=dotted_as_name b=(',' c=dotted_as_name { c })* { seq_insert_in_front(p, a, b) }
 dotted_as_name[alias_ty]:
     | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -51,7 +51,7 @@ import_from[stmt_ty]:
 import_from_targets[asdl_seq*]:
     | '(' a=import_from_as_names ')' { a }
     | import_from_as_names
-    | a='*' { singleton_seq(p, a) }
+    | a='*' { singleton_seq(p, alias_for_star(p)) }
 import_from_as_names[asdl_seq*]: a=import_from_as_name b=(',' c=import_from_as_name { c })* [','] { seq_insert_in_front(p, a, b) }
 import_from_as_name[alias_ty]:
     | a=NAME 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -561,3 +561,21 @@ join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
                 second_name->end_col_offset,
                 p->arena);
 }
+
+int
+seq_count_dots(asdl_seq *seq)
+{
+    int number_of_dots = 0;
+    for (int i = 0, l = asdl_seq_LEN(seq); i < l; i++) {
+        Token *current_expr = asdl_seq_GET(seq, i);
+        if (current_expr->type == ELLIPSIS) {
+            number_of_dots += 3;
+        } else if (current_expr->type == DOT) {
+            number_of_dots += 1;
+        } else {
+            return -1;
+        }
+    }
+
+    return number_of_dots;
+}

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -579,3 +579,16 @@ seq_count_dots(asdl_seq *seq)
 
     return number_of_dots;
 }
+
+alias_ty
+alias_for_star(Parser *p)
+{
+    PyObject *str = PyUnicode_InternFromString("*");
+    if (!str)
+        return NULL;
+    if (PyArena_AddPyObject(p->arena, str) < 0) {
+        Py_DECREF(str);
+        return NULL;
+    }
+    return alias(str, NULL, p->arena);
+}

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -61,3 +61,4 @@ asdl_seq *singleton_seq(Parser *, void *);
 asdl_seq *seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *seq_flatten(Parser *, asdl_seq *);
 expr_ty join_names_with_dot(Parser *, expr_ty, expr_ty);
+int seq_count_dots(asdl_seq *);

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -62,3 +62,4 @@ asdl_seq *seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *seq_flatten(Parser *, asdl_seq *);
 expr_ty join_names_with_dot(Parser *, expr_ty, expr_ty);
 int seq_count_dots(asdl_seq *);
+alias_ty alias_for_star(Parser *);

--- a/test/test_data/import_from.py
+++ b/test/test_data/import_from.py
@@ -1,0 +1,1 @@
+from a import b

--- a/test/test_data/import_from_alias.py
+++ b/test/test_data/import_from_alias.py
@@ -1,0 +1,1 @@
+from a import b as c

--- a/test/test_data/import_from_dotted.py
+++ b/test/test_data/import_from_dotted.py
@@ -1,0 +1,1 @@
+from a.b import c

--- a/test/test_data/import_from_dotted_alias.py
+++ b/test/test_data/import_from_dotted_alias.py
@@ -1,0 +1,1 @@
+from a.b import c as d

--- a/test/test_data/import_from_multiple_aliases.py
+++ b/test/test_data/import_from_multiple_aliases.py
@@ -1,0 +1,1 @@
+from a import b as c, d as e

--- a/test/test_data/import_from_one_dot.py
+++ b/test/test_data/import_from_one_dot.py
@@ -1,0 +1,1 @@
+from .a import b

--- a/test/test_data/import_from_one_dot_alias.py
+++ b/test/test_data/import_from_one_dot_alias.py
@@ -1,0 +1,1 @@
+from .a import b as c

--- a/test/test_data/import_from_star.py
+++ b/test/test_data/import_from_star.py
@@ -1,0 +1,1 @@
+from a import *

--- a/test/test_data/import_from_three_dots.py
+++ b/test/test_data/import_from_three_dots.py
@@ -1,0 +1,1 @@
+from ...a import b


### PR DESCRIPTION
This completes all the work needed for correctly generating the AST for every `import` statement.