### PR TITLE
Implement dot operator

### DIFF
--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -72,7 +72,7 @@ class Rule:
     def is_loop(self) -> bool:
         return self.name.startswith("_loop")
 
-    def is_tmp_with_sep(self) -> bool:
+    def is_node_with_sep(self) -> bool:
         return self.name.startswith("_tmp_sep")
 
     def __str__(self) -> str:

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -72,8 +72,8 @@ class Rule:
     def is_loop(self) -> bool:
         return self.name.startswith("_loop")
 
-    def is_loop_with_sep(self) -> bool:
-        return self.name.startswith("_loop_sep")
+    def is_tmp_with_sep(self) -> bool:
+        return self.name.startswith("_tmp_sep")
 
     def __str__(self) -> str:
         if self.type is None:

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -72,7 +72,7 @@ class Rule:
     def is_loop(self) -> bool:
         return self.name.startswith("_loop")
 
-    def is_node_with_sep(self) -> bool:
+    def is_gather(self) -> bool:
         return self.name.startswith("_tmp_sep")
 
     def __str__(self) -> str:
@@ -383,15 +383,15 @@ class Repeat1(Repeat):
 
 
 class RepeatWithSeparator(Repeat):
-    def __init__(self, separator: str, node: Plain):
+    def __init__(self, separator: Plain, node: Plain):
         self.separator = separator
         self.node = node
 
     def __str__(self) -> str:
-        return f"{self.separator}.{self.node!s}"
+        return f"{self.separator!s}.{self.node!s}"
 
     def __repr__(self) -> str:
-        return f"RepeatWithSeparator({self.separator}, {self.node!r})"
+        return f"RepeatWithSeparator({self.separator!r}, {self.node!r})"
 
     def nullable_visit(self, rules: Dict[str, Rule]) -> bool:
         return False

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -72,6 +72,9 @@ class Rule:
     def is_loop(self) -> bool:
         return self.name.startswith("_loop")
 
+    def is_loop_with_sep(self) -> bool:
+        return self.name.startswith("_loop_sep")
+
     def __str__(self) -> str:
         if self.type is None:
             return f"{self.name}: {self.rhs}"
@@ -374,6 +377,21 @@ class Repeat1(Repeat):
 
     def __repr__(self) -> str:
         return f"Repeat1({self.node!r})"
+
+    def nullable_visit(self, rules: Dict[str, Rule]) -> bool:
+        return False
+
+
+class RepeatWithSeparator(Repeat):
+    def __init__(self, separator: str, node: Plain):
+        self.separator = separator
+        self.node = node
+
+    def __str__(self) -> str:
+        return f"{self.separator}.{self.node!s}"
+
+    def __repr__(self) -> str:
+        return f"RepeatWithSeparator({self.separator}, {self.node!r})"
 
     def nullable_visit(self, rules: Dict[str, Rule]) -> bool:
         return False

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -447,7 +447,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def item(self) -> Optional[Item]:
-        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | STRING '.' atom { RepeatWithSeparator ( string . string , atom ) } | atom { atom }
+        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | sep=atom '.' node=atom '+' { RepeatWithSeparator ( sep , node ) } | atom { atom }
         mark = self.mark()
         cut = False
         if (
@@ -491,13 +491,15 @@ class GeneratedParser(Parser):
         if cut: return None
         cut = False
         if (
-            (string := self.string())
+            (sep := self.atom())
             and
             (literal := self.expect('.'))
             and
-            (atom := self.atom())
+            (node := self.atom())
+            and
+            (literal_1 := self.expect('+'))
         ):
-            return RepeatWithSeparator ( string . string , atom )
+            return RepeatWithSeparator ( sep , node )
         self.reset(mark)
         if cut: return None
         cut = False

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -28,6 +28,7 @@ from pegen.grammar import (
     PositiveLookahead,
     Repeat0,
     Repeat1,
+    RepeatWithSeparator,
     Rhs,
     Rule,
     RuleList,
@@ -446,7 +447,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def item(self) -> Optional[Item]:
-        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | atom { atom }
+        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | STRING '.' atom { RepeatWithSeparator ( string . string , atom ) } | atom { atom }
         mark = self.mark()
         cut = False
         if (
@@ -486,6 +487,17 @@ class GeneratedParser(Parser):
             (literal := self.expect('+'))
         ):
             return Repeat1 ( atom )
+        self.reset(mark)
+        if cut: return None
+        cut = False
+        if (
+            (string := self.string())
+            and
+            (literal := self.expect('.'))
+            and
+            (atom := self.atom())
+        ):
+            return RepeatWithSeparator ( string . string , atom )
         self.reset(mark)
         if cut: return None
         cut = False

--- a/pegen/metagrammar.gram
+++ b/pegen/metagrammar.gram
@@ -19,6 +19,7 @@ from pegen.grammar import (
     PositiveLookahead,
     Repeat0,
     Repeat1,
+    RepeatWithSeparator,
     Rhs,
     Rule,
     RuleList,
@@ -90,6 +91,7 @@ item[Item]:
     |  atom '?' {Opt(atom)}
     |  atom '*' {Repeat0(atom)}
     |  atom '+' {Repeat1(atom)}
+    |  STRING '.' atom {RepeatWithSeparator(string.string, atom)}
     |  atom {atom}
 
 atom[Plain]:

--- a/pegen/metagrammar.gram
+++ b/pegen/metagrammar.gram
@@ -91,7 +91,7 @@ item[Item]:
     |  atom '?' {Opt(atom)}
     |  atom '*' {Repeat0(atom)}
     |  atom '+' {Repeat1(atom)}
-    |  STRING '.' atom {RepeatWithSeparator(string.string, atom)}
+    |  sep=atom '.' node=atom '+' {RepeatWithSeparator(sep, node)}
     |  atom {atom}
 
 atom[Plain]:

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -110,7 +110,7 @@ class ParserGenerator:
                 [
                     Alt(
                         [
-                            NamedItem(None, StringLeaf(node.separator)),
+                            NamedItem(None, node.separator),
                             NamedItem("elem", node.node),
                         ],
                         action="elem",

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -98,7 +98,7 @@ class ParserGenerator:
         self.todo[name] = Rule(name, None, Rhs([Alt([NamedItem(None, node)])]))
         return name
 
-    def name_loop_with_sep(self, node: RepeatWithSeparator) -> str:
+    def name_node_with_sep(self, node: RepeatWithSeparator) -> str:
         self.counter += 1
         name = f"_tmp_sep_{self.counter}"
         self.counter += 1

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -100,7 +100,7 @@ class ParserGenerator:
 
     def name_loop_with_sep(self, node: RepeatWithSeparator) -> str:
         self.counter += 1
-        name = f"_loop_sep_{self.counter}"
+        name = f"_tmp_sep_{self.counter}"
         self.counter += 1
         extra_function_name = f"_loop0_{self.counter}"
         self.todo[extra_function_name] = Rule(
@@ -128,7 +128,6 @@ class ParserGenerator:
                             NamedItem("elem", node.node),
                             NamedItem("seq", NameLeaf(extra_function_name)),
                         ],
-                        action="[elem] + seq",
                     )
                 ]
             ),

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -5,7 +5,17 @@ from abc import abstractmethod
 from typing import AbstractSet, Dict, IO, Iterator, List, Optional, Set, Text, Tuple
 
 from pegen import sccutils
-from pegen.grammar import Grammar, Rule, Rhs, Alt, NamedItem, Plain, NameLeaf
+from pegen.grammar import (
+    Grammar,
+    Rule,
+    Rhs,
+    Alt,
+    NamedItem,
+    Plain,
+    NameLeaf,
+    StringLeaf,
+    RepeatWithSeparator,
+)
 from pegen.grammar import GrammarError, GrammarVisitor
 
 
@@ -86,6 +96,43 @@ class ParserGenerator:
             prefix = "_loop0_"
         name = f"{prefix}{self.counter}"  # TODO: It's ugly to signal via the name.
         self.todo[name] = Rule(name, None, Rhs([Alt([NamedItem(None, node)])]))
+        return name
+
+    def name_loop_with_sep(self, node: RepeatWithSeparator) -> str:
+        self.counter += 1
+        name = f"_loop_sep_{self.counter}"
+        self.counter += 1
+        extra_function_name = f"_loop0_{self.counter}"
+        self.todo[extra_function_name] = Rule(
+            extra_function_name,
+            None,
+            Rhs(
+                [
+                    Alt(
+                        [
+                            NamedItem(None, StringLeaf(node.separator)),
+                            NamedItem("elem", node.node),
+                        ],
+                        action="elem",
+                    )
+                ]
+            ),
+        )
+        self.todo[name] = Rule(
+            name,
+            None,
+            Rhs(
+                [
+                    Alt(
+                        [
+                            NamedItem("elem", node.node),
+                            NamedItem("seq", NameLeaf(extra_function_name)),
+                        ],
+                        action="[elem] + seq",
+                    )
+                ]
+            ),
+        )
         return name
 
 

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -103,35 +103,16 @@ class ParserGenerator:
         name = f"_tmp_sep_{self.counter}"
         self.counter += 1
         extra_function_name = f"_loop0_{self.counter}"
+        extra_function_alt = Alt(
+            [NamedItem(None, node.separator), NamedItem("elem", node.node),], action="elem",
+        )
         self.todo[extra_function_name] = Rule(
-            extra_function_name,
-            None,
-            Rhs(
-                [
-                    Alt(
-                        [
-                            NamedItem(None, node.separator),
-                            NamedItem("elem", node.node),
-                        ],
-                        action="elem",
-                    )
-                ]
-            ),
+            extra_function_name, None, Rhs([extra_function_alt]),
         )
-        self.todo[name] = Rule(
-            name,
-            None,
-            Rhs(
-                [
-                    Alt(
-                        [
-                            NamedItem("elem", node.node),
-                            NamedItem("seq", NameLeaf(extra_function_name)),
-                        ],
-                    )
-                ]
-            ),
+        alt = Alt(
+            [NamedItem("elem", node.node), NamedItem("seq", NameLeaf(extra_function_name)),],
         )
+        self.todo[name] = Rule(name, None, Rhs([alt]),)
         return name
 
 

--- a/pegen/python_generator.py
+++ b/pegen/python_generator.py
@@ -147,7 +147,7 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
 
     def visit_Rule(self, node: Rule) -> None:
         is_loop = node.is_loop()
-        is_loop_with_sep = node.is_loop_with_sep()
+        is_tmp_with_sep = node.is_tmp_with_sep()
         rhs = node.flatten()
         if node.left_recursive:
             if node.leader:
@@ -167,7 +167,7 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
             self.print("mark = self.mark()")
             if is_loop:
                 self.print("children = []")
-            self.visit(rhs, is_loop=is_loop, is_loop_with_sep=is_loop_with_sep)
+            self.visit(rhs, is_loop=is_loop, is_tmp_with_sep=is_tmp_with_sep)
             if is_loop:
                 self.print("return children")
             else:
@@ -184,13 +184,13 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
                 name = dedupe(name, names)
             self.print(f"({name} := {call})")
 
-    def visit_Rhs(self, node: Rhs, is_loop: bool = False, is_loop_with_sep: bool = False) -> None:
+    def visit_Rhs(self, node: Rhs, is_loop: bool = False, is_tmp_with_sep: bool = False) -> None:
         if is_loop:
             assert len(node.alts) == 1
         for alt in node.alts:
-            self.visit(alt, is_loop=is_loop, is_loop_with_sep=is_loop_with_sep)
+            self.visit(alt, is_loop=is_loop, is_tmp_with_sep=is_tmp_with_sep)
 
-    def visit_Alt(self, node: Alt, is_loop: bool, is_loop_with_sep: bool) -> None:
+    def visit_Alt(self, node: Alt, is_loop: bool, is_tmp_with_sep: bool) -> None:
         names: List[str] = []
         self.print("cut = False")  # TODO: Only if needed.
         if is_loop:
@@ -209,12 +209,13 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
         with self.indent():
             action = node.action
             if not action:
-                action = f"[{', '.join(names)}]"
-            if is_loop:
-                if is_loop_with_sep:
-                    self.print(f"children.extend({action})")
+                if is_tmp_with_sep:
+                    assert len(names) == 2
+                    action = f"[{names[0]}] + {names[1]}"
                 else:
-                    self.print(f"children.append({action})")
+                    action = f"[{', '.join(names)}]"
+            if is_loop:
+                self.print(f"children.append({action})")
                 self.print(f"mark = self.mark()")
             else:
                 self.print(f"return {action}")

--- a/test/test_pegen.py
+++ b/test/test_pegen.py
@@ -49,13 +49,14 @@ def test_typed_rules():
 
 def test_repeat_with_separator_rules():
     grammar = """
-    start: ','.thing NEWLINE
+    start: ','.thing+ NEWLINE
     thing: NUMBER
     """
     rules = parse_string(grammar, GrammarParser).rules
     assert str(rules["start"]) == "start: ','.thing NEWLINE"
+    print(repr(rules["start"]))
     assert repr(rules["start"]).startswith(
-        "Rule('start', None, Rhs([Alt([NamedItem(None, RepeatWithSeparator(',', NameLeaf('thing'"
+        "Rule('start', None, Rhs([Alt([NamedItem(None, RepeatWithSeparator(StringLeaf(\"','\"), NameLeaf('thing'"
     )
     assert str(rules["thing"]) == "thing: NUMBER"
 
@@ -246,7 +247,7 @@ def test_repeat_1_complex():
 
 def test_repeat_with_sep_simple():
     grammar = """
-    start: ','.thing NEWLINE
+    start: ','.thing+ NEWLINE
     thing: NUMBER
     """
     parser_class = make_parser(grammar)

--- a/test/test_pegen.py
+++ b/test/test_pegen.py
@@ -47,6 +47,19 @@ def test_typed_rules():
     )
 
 
+def test_repeat_with_separator_rules():
+    grammar = """
+    start: ','.thing NEWLINE
+    thing: NUMBER
+    """
+    rules = parse_string(grammar, GrammarParser).rules
+    assert str(rules["start"]) == "start: ','.thing NEWLINE"
+    assert repr(rules["start"]).startswith(
+        "Rule('start', None, Rhs([Alt([NamedItem(None, RepeatWithSeparator(',', NameLeaf('thing'"
+    )
+    assert str(rules["thing"]) == "thing: NUMBER"
+
+
 def test_expr_grammar():
     grammar = """
     start: sum NEWLINE
@@ -229,6 +242,23 @@ def test_repeat_1_complex():
     ]
     with pytest.raises(SyntaxError):
         parse_string("1\n", parser_class)
+
+
+def test_repeat_with_sep_simple():
+    grammar = """
+    start: ','.thing NEWLINE
+    thing: NUMBER
+    """
+    parser_class = make_parser(grammar)
+    node = parse_string("1, 2, 3\n", parser_class)
+    assert node == [
+        [
+            [TokenInfo(NUMBER, string="1", start=(1, 0), end=(1, 1), line="1, 2, 3\n")],
+            [TokenInfo(NUMBER, string="2", start=(1, 3), end=(1, 4), line="1, 2, 3\n")],
+            [TokenInfo(NUMBER, string="3", start=(1, 6), end=(1, 7), line="1, 2, 3\n")],
+        ],
+        TokenInfo(NEWLINE, string="\n", start=(1, 7), end=(1, 8), line="1, 2, 3\n"),
+    ]
 
 
 def test_left_recursive():


### PR DESCRIPTION
Implement dot operator, which gathers the parsed nodes into a sequence, ignoring their separators(such as a comma):
    * Add node in grammar.py
    * Generate correct Python code for new node

I didn't get to implement the generation of C code for this, but I'd like to have a 'go' or 'no go' before I do, regarding the way I implemented this. Could it be maybe done better?