### PR TITLE
Grammar refactorings for while and for rules

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -100,13 +100,13 @@ elif_stmt[stmt_ty]:
         _Py_If(b, c, NULL, EXTRA(b, expr_type, seq_get_tail(NULL, c), stmt_type)) }
 else_block[asdl_seq*]: 'else' ':' b=block { b }
 
-while_stmt:
+while_stmt[stmt_ty]:
     | a='while' ex=full_expression ':' b=block el=else_block {
         _Py_While(ex, b, el, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
     | a='while' ex=full_expression ':' b=block {
         _Py_While(ex, b, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
 
-for_stmt:
+for_stmt[stmt_ty]:
     | a=ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block el=else_block {
         _Py_AsyncFor(t, ex, b, el, NULL, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
     | a=ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block {

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -21,7 +21,7 @@ small_stmt[stmt_ty]:
     | continue_stmt
     | assignment
     | e=expressions { _Py_Expr(e, EXTRA_EXPR(e, e)) }
-compound_stmt: if_stmt | while_stmt | for_stmt | with_stmt | try_stmt | function_def | class_def
+compound_stmt[stmt_ty]: if_stmt | while_stmt | for_stmt | with_stmt | try_stmt | function_def | class_def
 
 # NOTE: yield_expression may start with 'yield'; yield_expr must start with 'yield'
 assignment: target ':' expression ['=' yield_expression] | (star_targets '=')+ (yield_expr | expressions) | target augassign (yield_expr | expressions)
@@ -100,9 +100,21 @@ elif_stmt[stmt_ty]:
         _Py_If(b, c, NULL, EXTRA(b, expr_type, seq_get_tail(NULL, c), stmt_type)) }
 else_block[asdl_seq*]: 'else' ':' b=block { b }
 
-while_stmt: 'while' full_expression ':' block [else_block]
+while_stmt:
+    | a='while' ex=full_expression ':' b=block el=else_block {
+        _Py_While(ex, b, el, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+    | a='while' ex=full_expression ':' b=block {
+        _Py_While(ex, b, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
 
-for_stmt: [ASYNC] 'for' star_targets 'in' expressions ':' block [else_block]
+for_stmt:
+    | a=ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block el=else_block {
+        _Py_AsyncFor(t, ex, b, el, NULL, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+    | a=ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block {
+        _Py_AsyncFor(t, ex, b, NULL, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+    | a='for' t=star_targets 'in' ex=expressions ':' b=block el=else_block {
+        _Py_For(t, ex, b, el, NULL, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+    | a='for' t=star_targets 'in' ex=expressions ':' b=block {
+        _Py_For(t, ex, b, NULL, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
 
 with_stmt: [ASYNC] 'with' expression ['as' target] (',' [expression ['as' target]])* ':' block
 
@@ -295,9 +307,9 @@ kwarg: NAME '=' expression | '*' expression | '**' expression
 # NOTE: star_targets may contain *NAME, targets may not.
 # NOTE: the !'in' is to handle "for x, in ...".
 # TODO: things like {k: v}[k] = v should also be acceptable [star] targets.
-star_targets: star_target (',' !'in' star_target)* [',']
-star_target: '*' bitwise_or | atom t_tail+ | star_atom t_tail*
-star_atom: NAME | '(' [star_targets] ')' | '[' [star_targets] ']'
+star_targets: a=star_target (',' !'in' star_target)* [','] { a }
+star_target: '*' bitwise_or | atom t_tail+ | a=star_atom t_tail* { a }
+star_atom: a=NAME { _Py_Name(((expr_ty) a)->v.Name.id, Store, EXTRA_EXPR(a, a)) } | '(' [star_targets] ')' | '[' [star_targets] ']'
 
 targets: target (',' target)* [',']
 target: atom t_tail+ | t_atom t_tail*

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -309,7 +309,7 @@ kwarg: NAME '=' expression | '*' expression | '**' expression
 # TODO: things like {k: v}[k] = v should also be acceptable [star] targets.
 star_targets: a=star_target (',' !'in' star_target)* [','] { a }
 star_target: '*' bitwise_or | atom t_tail+ | a=star_atom t_tail* { a }
-star_atom: a=NAME { _Py_Name(((expr_ty) a)->v.Name.id, Store, EXTRA_EXPR(a, a)) } | '(' [star_targets] ')' | '[' [star_targets] ']'
+star_atom: a=NAME { store_name(p, a) } | '(' [star_targets] ')' | '[' [star_targets] ']'
 
 targets: target (',' target)* [',']
 target: atom t_tail+ | t_atom t_tail*

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -686,3 +686,10 @@ Pegen_Compare(Parser *p, expr_ty expr, asdl_seq *pairs)
                        EXTRA_EXPR(expr, ((CmpopExprPair *) seq_get_tail(NULL, pairs))->expr));
 }
 
+expr_ty
+store_name(Parser *p, expr_ty load_name)
+{
+    return _Py_Name(load_name->v.Name.id,
+                    Store,
+                    EXTRA_EXPR(load_name, load_name));
+}

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -79,6 +79,7 @@ PegenAlias *pegen_alias(alias_ty, int, int, int, int, PyArena *);
 asdl_seq *seq_map_to_alias(Parser *, asdl_seq *);
 CmpopExprPair *cmpop_expr_pair(Parser *, cmpop_ty, expr_ty);
 expr_ty Pegen_Compare(Parser *, expr_ty, asdl_seq *);
+expr_ty store_name(Parser *, expr_ty);
 
 inline int expr_type_headline(expr_ty a) { return a->lineno; }
 inline int expr_type_headcol(expr_ty a) { return a->col_offset; }

--- a/test/test_data/asyncfor.py
+++ b/test/test_data/asyncfor.py
@@ -1,0 +1,2 @@
+async for i in a:
+    pass

--- a/test/test_data/for.py
+++ b/test/test_data/for.py
@@ -1,0 +1,2 @@
+for i in a:
+    pass

--- a/test/test_data/for_else.py
+++ b/test/test_data/for_else.py
@@ -1,0 +1,4 @@
+for i in a:
+    pass
+else:
+    pass

--- a/test/test_data/for_underscore.py
+++ b/test/test_data/for_underscore.py
@@ -1,0 +1,2 @@
+for _ in a:
+    pass

--- a/test/test_data/while.py
+++ b/test/test_data/while.py
@@ -1,0 +1,2 @@
+while a:
+    pass

--- a/test/test_data/while_else.py
+++ b/test/test_data/while_else.py
@@ -1,0 +1,4 @@
+while a:
+    pass
+else:
+    pass


### PR DESCRIPTION
There is still the problem mentioned in #77, where merging the alternatives in one, where the `else_block` would be optional, requires nested calls of `seq_get_tail`.

Also fixes #79.