### PR TITLE
Check for errors when calling PyUnicode_DecodeUTF8

### DIFF
--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -559,6 +559,9 @@ join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
                                          PyBytes_GET_SIZE(str),
                                          NULL);
     Py_DECREF(str);
+    if (!uni) {
+        return NULL;
+    }
     PyUnicode_InternInPlace(&uni);
     if (PyArena_AddPyObject(p->arena, uni) < 0) {
         Py_DECREF(uni);


### PR DESCRIPTION
Internal errors and exceptions by the underlying codec can be raised when calling `PyUnicode_DecodeUTF8`.