### PR TITLE
Add a -t flag to scripts/test_parse_directory.py to compare parse trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GRAMMAR = data/cprog.gram
 TESTFILE = data/cprog.txt
 TIMEFILE = data/xxl.txt
 TESTDIR = .
+TESTFLAGS = --short
 
 build: pegen/parse.c
 
@@ -42,7 +43,7 @@ simpy:
 	$(PYTHON) scripts/test_parse_directory.py \
 		-g data/simpy.gram \
 		-d $(TESTDIR) \
-		--short \
+		$(TESTFLAGS) \
 		--exclude "*/failset/*" \
 		--exclude "*/failset/**" \
 		--exclude "*/failset/**/*"
@@ -51,7 +52,7 @@ simpy_cpython:
 	$(PYTHON) scripts/test_parse_directory.py \
 		-g data/simpy.gram \
 		-d $(CPYTHON) \
-		--short \
+		$(TESTFLAGS) \
 		--exclude "*/test2to3/*" \
 		--exclude "*/test2to3/**/*" \
 		--exclude "*/bad*" \

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# This exists to let mypy find modules here

--- a/scripts/show_parse.py
+++ b/scripts/show_parse.py
@@ -52,7 +52,10 @@ def format_tree(tree: ast.AST, verbose: bool = False) -> str:
         tf.write(ast.dump(tree, include_attributes=verbose))
         tf.write("\n")
         tf.flush()
-        os.system(f"black -q {tf.name}")
+        cmd = f"black -q {tf.name}"
+        sts = os.system(cmd)
+        if sts:
+            raise RuntimeError(f"Command {cmd!r} failed with status 0x{sts:x}")
         tf.seek(0)
         return tf.read()
 

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -82,8 +82,10 @@ def compare_trees(
     expected_text = ast.dump(expected_tree, include_attributes=include_attributes)
     actual_text = ast.dump(actual_tree, include_attributes=include_attributes)
     if actual_text == expected_text:
-        if not verbose:
-            return
+        if verbose:
+            print("Tree for {file}:")
+            print(show_parse.format_tree(actual_tree, include_attributes))
+        return
 
     print(f"Diffing ASTs for {file} ...")
 

--- a/test/test_data/def_noargs.py
+++ b/test/test_data/def_noargs.py
@@ -1,2 +1,0 @@
-def foo():
-    pass

--- a/test/test_data/def_noargs.py
+++ b/test/test_data/def_noargs.py
@@ -1,0 +1,2 @@
+def foo():
+    pass


### PR DESCRIPTION
This adds the functionality of scripts/show_parse.py to the `make simpy` command; just use
```
make simpy TESTFLAGS=-st
```
Use `-stt` to include line/column info into the tree dumps being compared.

This also works for `make simpy_cpython` (but will be excruciatingly slow).