### PR TITLE
Move the definition of the inline functions to pegen.c

### DIFF
--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -121,23 +121,23 @@ arguments_ty empty_arguments(Parser *);
 AugOperator *augoperator(Parser*, operator_ty type);
 expr_ty construct_assign_target(Parser *p, expr_ty node);
 
-inline int expr_type_headline(expr_ty a) { return a->lineno; }
-inline int expr_type_headcol(expr_ty a) { return a->col_offset; }
-inline int expr_type_tailline(expr_ty a) { return a->end_lineno; }
-inline int expr_type_tailcol(expr_ty a) { return a->end_col_offset; }
-inline int stmt_type_headline(stmt_ty a) { return a->lineno; }
-inline int stmt_type_headcol(stmt_ty a) { return a->col_offset; }
-inline int stmt_type_tailline(stmt_ty a) { return a->end_lineno; }
-inline int stmt_type_tailcol(stmt_ty a) { return a->end_col_offset; }
-inline int excepthandler_type_headline(excepthandler_ty a) { return a->lineno; }
-inline int excepthandler_type_headcol(excepthandler_ty a) { return a->col_offset; }
-inline int excepthandler_type_tailline(excepthandler_ty a) { return a->end_lineno; }
-inline int excepthandler_type_tailcol(excepthandler_ty a) { return a->end_col_offset; }
-inline int token_type_headline(Token *a) { return a->lineno; }
-inline int token_type_headcol(Token *a) { return a->col_offset; }
-inline int token_type_tailline(Token *a) { return a->end_lineno; }
-inline int token_type_tailcol(Token *a) { return a->end_col_offset; }
-inline int alias_type_headline(PegenAlias *a) { return a->lineno; }
-inline int alias_type_headcol(PegenAlias *a) { return a->col_offset; }
-inline int alias_type_tailline(PegenAlias *a) { return a->end_lineno; }
-inline int alias_type_tailcol(PegenAlias *a) { return a->end_col_offset; }
+static inline int expr_type_headline(expr_ty a) { return a->lineno; }
+static inline int expr_type_headcol(expr_ty a) { return a->col_offset; }
+static inline int expr_type_tailline(expr_ty a) { return a->end_lineno; }
+static inline int expr_type_tailcol(expr_ty a) { return a->end_col_offset; }
+static inline int stmt_type_headline(stmt_ty a) { return a->lineno; }
+static inline int stmt_type_headcol(stmt_ty a) { return a->col_offset; }
+static inline int stmt_type_tailline(stmt_ty a) { return a->end_lineno; }
+static inline int stmt_type_tailcol(stmt_ty a) { return a->end_col_offset; }
+static inline int excepthandler_type_headline(excepthandler_ty a) { return a->lineno; }
+static inline int excepthandler_type_headcol(excepthandler_ty a) { return a->col_offset; }
+static inline int excepthandler_type_tailline(excepthandler_ty a) { return a->end_lineno; }
+static inline int excepthandler_type_tailcol(excepthandler_ty a) { return a->end_col_offset; }
+static inline int token_type_headline(Token *a) { return a->lineno; }
+static inline int token_type_headcol(Token *a) { return a->col_offset; }
+static inline int token_type_tailline(Token *a) { return a->end_lineno; }
+static inline int token_type_tailcol(Token *a) { return a->end_col_offset; }
+static inline int alias_type_headline(PegenAlias *a) { return a->lineno; }
+static inline int alias_type_headcol(PegenAlias *a) { return a->col_offset; }
+static inline int alias_type_tailline(PegenAlias *a) { return a->end_lineno; }
+static inline int alias_type_tailcol(PegenAlias *a) { return a->end_col_offset; }


### PR DESCRIPTION
As pegen.h is included both in pegen.c and the generated parser file,
having the definition of the inline functions in the header file can
lead to double definition errors if the extension is compiled without
optimizations (-O0) due to the fact that the function is not inlined in
such scenario and then it becomes a regular function that suffers from
double definition.