### PR TITLE
Use the 3.8-dev branch in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.8
+python: 3.8-dev
 
 notifications:
   on_success: change


### PR DESCRIPTION
Meanwhile we wait for the 3.8.1 version to be available in travis,
use the development branch build to pick up the latest AST bugfixes.