### PR TITLE
Generate type for NAME, STRING and NUMBER variables

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -79,7 +79,7 @@ import_from_targets[asdl_seq*]:
 import_from_as_names[asdl_seq*]:
     | a=','.import_from_as_name+ [','] { a }
 import_from_as_name[alias_ty]:
-    | a=NAME b=['as' z=NAME { z }] { _Py_alias(((expr_ty) a)->v.Name.id,
+    | a=NAME b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                p->arena) }
 dotted_as_names[asdl_seq*]:
@@ -144,11 +144,11 @@ function_def[stmt_ty]:
 
 function_def_raw[stmt_ty]:
     | ASYNC 'def' n=NAME '(' params=[parameters] ')' a=['->' z=annotation { z }] ':' b=block {
-        _Py_AsyncFunctionDef(((expr_ty) n)->v.Name.id,
+        _Py_AsyncFunctionDef(n->v.Name.id,
                              (params) ? params : empty_arguments(p),
                              b, NULL, a, NULL, EXTRA) }
     | 'def' n=NAME '(' params=[parameters] ')' a=['->' z=annotation { z }] ':' b=block {
-        _Py_FunctionDef(((expr_ty) n)->v.Name.id,
+        _Py_FunctionDef(n->v.Name.id,
                         (params) ? params : empty_arguments(p),
                         b, NULL, a, NULL, EXTRA) }
 
@@ -177,7 +177,7 @@ name_with_default[NameDefaultPair*]:
     | n=plain_name '=' e=expression { name_default_pair(p, n, e) }
 plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
 plain_name[arg_ty]:
-    | a=NAME b=[':' z=annotation { z }] { _Py_arg(((expr_ty) a)->v.Name.id, b, NULL, EXTRA) }
+    | a=NAME b=[':' z=annotation { z }] { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
 kwds[arg_ty]:
     | '**' a=plain_name { a }
 annotation[expr_ty]: expression
@@ -189,7 +189,7 @@ class_def[stmt_ty]:
     | class_def_raw
 class_def_raw[stmt_ty]:
     | 'class' a=NAME b=['(' z=[arguments] ')' { z }] ':' c=block {
-        _Py_ClassDef(((expr_ty) a)->v.Name.id,
+        _Py_ClassDef(a->v.Name.id,
                      (b) ? ((expr_ty) b)->v.Call.args : NULL,
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
@@ -245,7 +245,7 @@ lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
 lambda_name_with_default[NameDefaultPair*]:
     | n=lambda_plain_name '=' e=expression { name_default_pair(p, n, e) }
 lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
-lambda_plain_name[arg_ty]: a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA) }
+lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
 lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
 
 disjunction[expr_ty]:
@@ -326,7 +326,7 @@ await_primary[expr_ty]:
     | AWAIT a=primary { _Py_Await(a, EXTRA) }
     | primary
 primary[expr_ty]:
-    | a=primary '.' b=NAME { _Py_Attribute(a, ((expr_ty) b)->v.Name.id, Load, EXTRA) }
+    | a=primary '.' b=NAME { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
     | a=primary b=slicing { _Py_Subscript(a, b, Load, EXTRA) }
     | a=primary b=genexp { _Py_Call(a, singleton_seq(p, b), NULL, EXTRA) }
     | a=primary '(' b=[arguments] ')' {
@@ -415,7 +415,7 @@ starred_expression[expr_ty]:
     | '*' a=expression { _Py_Starred(a, Load, EXTRA) }
 kwarg[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
-        keyword_or_starred(p, _Py_keyword(((expr_ty) a)->v.Name.id, b, p->arena), 1) }
+        keyword_or_starred(p, _Py_keyword(a->v.Name.id, b, p->arena), 1) }
     | a=starred_expression { keyword_or_starred(p, a, 0) }
     | '**' a=expression { keyword_or_starred(p, _Py_keyword(NULL, a, p->arena), 1) }
 

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -492,6 +492,8 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                     type = rule.type
             elif name.startswith("_loop") or name.startswith("_gather"):
                 type = "asdl_seq *"
+            elif name.startswith("name") or name.startswith("string") or name.startswith("number"):
+                type = "expr_ty"
         if node.name:
             name = node.name
         name = dedupe(name, names)

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -492,7 +492,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                     type = rule.type
             elif name.startswith("_loop") or name.startswith("_gather"):
                 type = "asdl_seq *"
-            elif name == "name_var" or name == "string_var" or name == "number_var":
+            elif name in ("name_var", "string_var", "number_var"):
                 type = "expr_ty"
         if node.name:
             name = node.name

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -492,7 +492,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                     type = rule.type
             elif name.startswith("_loop") or name.startswith("_gather"):
                 type = "asdl_seq *"
-            elif name.startswith("name") or name.startswith("string") or name.startswith("number"):
+            elif name == "name_var" or name == "string_var" or name == "number_var":
                 type = "expr_ty"
         if node.name:
             name = node.name


### PR DESCRIPTION
We can now avoid unnecessary casts in the grammar.