### PR TITLE
Do not optimize away asserts in the CI

### DIFF
--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -43,6 +43,9 @@ argparser.add_argument(
     help="Where to write the generated parser (default parse.py or parse.c)",
 )
 argparser.add_argument("filename", help="Grammar description")
+argparser.add_argument(
+    "--optimized", action="store_true", help="Compile the extension in optimized mode"
+)
 
 
 def main() -> None:
@@ -67,6 +70,7 @@ def main() -> None:
             verbose_tokenizer,
             verbose_parser,
             args.verbose,
+            keep_asserts_in_extension=False if args.optimized else True,
         )
     except Exception as err:
         if args.verbose:


### PR DESCRIPTION
This makes sure that assets are not optimized away (they are now because the extension inherits the config variables from the Python build in Travis and that one is not compiled in debug mode). This change will allow Travis to detect failures similar to the one in #140 as well as check that the asserts themselves do not fail.