### PR TITLE
Add del_targets

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -55,8 +55,7 @@ yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
 
 assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
 
-del_stmt[stmt_ty]: 'del' a=targets { # TODO: exclude *target
-    _Py_Delete(set_seq_context(p, a, Del), EXTRA) }
+del_stmt[stmt_ty]: 'del' a=del_targets { _Py_Delete(a, EXTRA) }
 
 pass_stmt[stmt_ty]: 'pass' { _Py_Pass(EXTRA) }
 
@@ -436,6 +435,16 @@ star_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=[star_targets_seq] ')' { _Py_Tuple(a, Store, EXTRA) }
     | '[' a=[star_targets_seq] ']' { _Py_List(a, Store, EXTRA) }
+
+del_targets[asdl_seq*]: a=','.del_target+ [','] { a }
+del_target[expr_ty]:
+    | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Del, EXTRA) }
+    | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Del, EXTRA) }
+    | del_t_atom
+del_t_atom[expr_ty]:
+    | a=NAME { set_expr_context(p, a, Del) }
+    | '(' b=[del_targets] ')' { _Py_Tuple(b, Del, EXTRA) }
+    | '[' b=[del_targets] ']' { _Py_List(b, Del, EXTRA) }
 
 targets[asdl_seq*]: a=','.target+ [','] { a }
 target[expr_ty]:

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -131,9 +131,6 @@ Wrapper for `_Py_Compare`, so that the call in the grammar stays concise.
 ###### `expr_ty set_expr_context(Parser *p, expr_ty expr, expr_context_ty ctx)`
 Creates an `expr_ty` equivalent to `expr` but with `ctx` as context.
 
-###### `asdl_seq *map_seq_to_context(Parser *p, asdl_seq *seq, expr_context_ty ctx)`
-Creates an `asdl_seq *` where all the elements have been changed to have `ctx` as context.
-
 ###### `KeyValuePair *key_value_pair(Parser *p, expr_ty key, expr_ty value)`
 Constructs a `KeyValuePair` that is used when parsing a dict's key value pairs.
 

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -104,7 +104,6 @@ asdl_seq *map_names_to_ids(Parser *, asdl_seq *);
 CmpopExprPair *cmpop_expr_pair(Parser *, cmpop_ty, expr_ty);
 expr_ty Pegen_Compare(Parser *, expr_ty, asdl_seq *);
 expr_ty set_expr_context(Parser *, expr_ty, expr_context_ty);
-asdl_seq *set_seq_context(Parser *, asdl_seq *, expr_context_ty);
 KeyValuePair *key_value_pair(Parser *, expr_ty, expr_ty);
 asdl_seq *get_keys(Parser *, asdl_seq *);
 asdl_seq *get_values(Parser *, asdl_seq *);


### PR DESCRIPTION
This deletes the only call to `set_seq_context` from the grammar, so I think it's actually useful.