### PR TITLE
Fix bug with starred expression in starred sequence

### DIFF
--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -128,6 +128,7 @@ TEST_CASES = [
             pass
      '''),
     ('for_star_targets_multiple', 'for a, b in c: pass'),
+    ('for_star_targets_nested_starred', 'for *[*a] in b: pass'),
     ('for_star_targets_starred', 'for *a in b: pass'),
     ('for_star_targets_subscript_attribute', 'for a[0].b in c: pass'),
     ('for_star_targets_trailing_comma',


### PR DESCRIPTION
There was a bug when the for target was something like `*[*a]`, because I hadn't included `Starred_kind` in the `set_expr_context` switch. I thought it was unnecessary, but it turns out it isn't. The reason is a Starred object can contain any atom, which means it could also be a sequence, which could contain a starred expressions itself. This starred expression's context needs to be correctly set. Unfortunately that is also the reason why we can't get rid of `_set_seq_context` altogether.

This is also removing some unnecessary code in `construct_assign_target`.