### PR TITLE
Refactor visit_Alt in the C generator

### DIFF
--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -451,7 +451,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             self.print(f"goto done;")
         self.print("}")
 
-    def _handle_repetitions(
+    def _handle_alt_loop(
         self, node: Alt, is_gather: bool, rulename: Optional[str], names: List[str]
     ) -> None:
         # Condition of the main body of the alternative
@@ -492,7 +492,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
 
             names: List[str] = []
             if is_loop:
-                self._handle_repetitions(node, is_gather, rulename, names)
+                self._handle_alt_loop(node, is_gather, rulename, names)
             else:
                 self._handle_options(node, is_gather, names)
 

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -435,7 +435,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 )
             self.print(f"res = {names[0]};")
 
-    def handle_alt_optional(self, node: Alt, is_gather: bool, names: List[str]) -> None:
+    def handle_alt_normal(self, node: Alt, is_gather: bool, names: List[str]) -> None:
         self.join_conditions(keyword="if", node=node, names=names)
         self.print("{")
         # We have parsed successfully all the conditions for the option.
@@ -494,7 +494,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             if is_loop:
                 self.handle_alt_loop(node, is_gather, rulename, names)
             else:
-                self.handle_alt_optional(node, is_gather, names)
+                self.handle_alt_normal(node, is_gather, names)
 
             self.print("p->mark = mark;")
             if "cut_var" in names:

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -398,68 +398,104 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         for alt in node.alts:
             self.visit(alt, is_loop=is_loop, is_gather=is_gather, rulename=rulename)
 
+    def _join_conditions(self, keyword: str, node: Any, names: List[str]) -> None:
+        self.print(f"{keyword} (")
+        with self.indent():
+            first = True
+            for item in node.items:
+                if first:
+                    first = False
+                else:
+                    self.print("&&")
+                self.visit(item, names=names)
+        self.print(")")
+
+    def _emit_action(self, node: Alt) -> None:
+        self.print(f"res = {node.action};")
+        if self.debug:
+            self.print(
+                f'fprintf(stderr, "Hit with action [%d-%d]: %s\\n", mark, p->mark, "{node}");'
+            )
+
+    def _emit_default_action(self, is_gather: bool, names: List[str], node: Alt) -> None:
+        if len(names) > 1:
+            if is_gather:
+                assert len(names) == 2
+                self.print(f"res = seq_insert_in_front(p, {names[0]}, {names[1]});")
+            else:
+                if self.debug:
+                    self.print(
+                        f'fprintf(stderr, "Hit without action [%d:%d]: %s\\n", mark, p->mark, "{node}");'
+                    )
+                self.print(f"res = CONSTRUCTOR(p, {', '.join(names)});")
+        else:
+            if self.debug:
+                self.print(
+                    f'fprintf(stderr, "Hit with default action [%d:%d]: %s\\n", mark, p->mark, "{node}");'
+                )
+            self.print(f"res = {names[0]};")
+
+    def _handle_options(self, node: Alt, is_gather: bool, names: List[str]) -> None:
+        self._join_conditions(keyword="if", node=node, names=names)
+        self.print("{")
+        # We have parsed successfully all the conditions for the option.
+        with self.indent():
+            # Prepare to emmit the rule action and do so
+            self._set_up_token_end_metadata_extraction()
+            if node.action:
+                self._emit_action(node)
+            else:
+                self._emit_default_action(is_gather, names, node)
+
+            # As the current option has parsed correctly, do not continue with the rest.
+            self.print(f"goto done;")
+        self.print("}")
+
+    def _handle_repetitions(
+        self, node: Alt, is_gather: bool, rulename: Optional[str], names: List[str]
+    ) -> None:
+        # Condition of the main body of the alternative
+        self._join_conditions(keyword="while", node=node, names=names)
+        self.print("{")
+        # We have parsed successfully one item!
+        with self.indent():
+            # Prepare to emmit the rule action and do so
+            self._set_up_token_end_metadata_extraction()
+            if node.action:
+                self._emit_action(node)
+            else:
+                self._emit_default_action(is_gather, names, node)
+
+            # Add the result of rule to the temporary buffer of children. This buffer
+            # will populate later an asdl_seq with all elements to return.
+            self.print("children = PyMem_Realloc(children, (n+1)*sizeof(void *));")
+            self.out_of_memory_return(f"!children", "NULL", message=f"realloc {rulename}")
+            self.print(f"children[n++] = res;")
+            self.print("mark = p->mark;")
+        self.print("}")
+
     def visit_Alt(
         self, node: Alt, is_loop: bool, is_gather: bool, rulename: Optional[str]
     ) -> None:
         self.print(f"{{ // {node}")
         with self.indent():
+            # Prepare variable declarations for the alternative
             vars = self.collect_vars(node)
-            for v, type in sorted(item for item in vars.items() if item[0] is not None):
-                if not type:
-                    type = "void *"
+            for v, var_type in sorted(item for item in vars.items() if item[0] is not None):
+                if not var_type:
+                    var_type = "void *"
                 else:
-                    type += " "
+                    var_type += " "
                 if v == "cut_var":
                     v += " = 0"  # cut_var must be initialized
-                self.print(f"{type}{v};")
+                self.print(f"{var_type}{v};")
+
             names: List[str] = []
             if is_loop:
-                self.print("while (")
+                self._handle_repetitions(node, is_gather, rulename, names)
             else:
-                self.print("if (")
-            with self.indent():
-                first = True
-                for item in node.items:
-                    if first:
-                        first = False
-                    else:
-                        self.print("&&")
-                    self.visit(item, names=names)
-            self.print(") {")
-            with self.indent():
-                self._set_up_token_end_metadata_extraction()
-                action = node.action
-                if not action:
-                    if len(names) > 1:
-                        if is_gather:
-                            assert len(names) == 2
-                            self.print(f"res = seq_insert_in_front(p, {names[0]}, {names[1]});")
-                        else:
-                            if self.debug:
-                                self.print(
-                                    f'fprintf(stderr, "Hit without action [%d:%d]: %s\\n", mark, p->mark, "{node}");'
-                                )
-                            self.print(f"res = CONSTRUCTOR(p, {', '.join(names)});")
-                    else:
-                        if self.debug:
-                            self.print(
-                                f'fprintf(stderr, "Hit with default action [%d:%d]: %s\\n", mark, p->mark, "{node}");'
-                            )
-                        self.print(f"res = {names[0]};")
-                else:
-                    self.print(f"res = {action};")
-                    if self.debug:
-                        self.print(
-                            f'fprintf(stderr, "Hit with action [%d-%d]: %s\\n", mark, p->mark, "{node}");'
-                        )
-                if is_loop:
-                    self.print("children = PyMem_Realloc(children, (n+1)*sizeof(void *));")
-                    self.out_of_memory_return(f"!children", "NULL", message=f"realloc {rulename}")
-                    self.print(f"children[n++] = res;")
-                    self.print("mark = p->mark;")
-                else:
-                    self.print(f"goto done;")
-            self.print("}")
+                self._handle_options(node, is_gather, names)
+
             self.print("p->mark = mark;")
             if "cut_var" in names:
                 self.print("if (cut_var) return NULL;")


### PR DESCRIPTION
While I was working on some improvements on the C generator and realized that the code for visiting alternatives was getting very complex and there were some opportunities for some refactoring:

To disentangle the generation of code for alternatives, separate explicitly the options from the repetitions as they are handled differently and have different cleanups. Additionally, create functions
for emitting the default action or the one specified for clarity.

Better name suggestions for the functions are welcomed! :)