### PR TITLE
Add --skip-actions flags to generate no (or at least minimal) actions

### DIFF
--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -46,6 +46,11 @@ argparser.add_argument("filename", help="Grammar description")
 argparser.add_argument(
     "--optimized", action="store_true", help="Compile the extension in optimized mode"
 )
+argparser.add_argument(
+    "--skip-actions",
+    action="store_true",
+    help="Don't generate action code (not even default actions)",
+)
 
 
 def main() -> None:
@@ -71,6 +76,7 @@ def main() -> None:
             verbose_parser,
             args.verbose,
             keep_asserts_in_extension=False if args.optimized else True,
+            skip_actions=args.skip_actions,
         )
     except Exception as err:
         if args.verbose:

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -137,7 +137,7 @@ def build_parser_and_generator(
           output when compiling the C extension . Defaults to False.
         keep_asserts_in_extension (bool, optional): Whether to keep the assert statements
           when compiling the extension module. Defaults to True.
-        skip_actions (boo, optional): Whether to pretend no rule has any actions.
+        skip_actions (bool, optional): Whether to pretend no rule has any actions.
     """
     grammar, parser, tokenizer = build_parser(grammar_file, verbose_tokenizer, verbose_parser)
     gen = build_generator(

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -92,13 +92,14 @@ def build_generator(
     compile_extension: bool = False,
     verbose_c_extension: bool = False,
     keep_asserts_in_extension: bool = True,
+    skip_actions: bool = False,
 ) -> ParserGenerator:
     with open(output_file, "w") as file:
         gen: ParserGenerator
         if output_file.endswith(".c"):
-            gen = CParserGenerator(grammar, file)
+            gen = CParserGenerator(grammar, file, skip_actions=skip_actions)
         elif output_file.endswith(".py"):
-            gen = PythonParserGenerator(grammar, file)
+            gen = PythonParserGenerator(grammar, file)  # TODO: skip_actions
         else:
             raise Exception("Your output file must either be a .c or .py file")
         gen.generate(grammar_file)
@@ -119,6 +120,7 @@ def build_parser_and_generator(
     verbose_parser: bool = False,
     verbose_c_extension: bool = False,
     keep_asserts_in_extension: bool = True,
+    skip_actions: bool = False,
 ) -> Tuple[Grammar, Parser, Tokenizer, ParserGenerator]:
     """Generate rules, parser, tokenizer, parser generator for a given grammar
 
@@ -135,6 +137,7 @@ def build_parser_and_generator(
           output when compiling the C extension . Defaults to False.
         keep_asserts_in_extension (bool, optional): Whether to keep the assert statements
           when compiling the extension module. Defaults to True.
+        skip_actions (boo, optional): Whether to pretend no rule has any actions.
     """
     grammar, parser, tokenizer = build_parser(grammar_file, verbose_tokenizer, verbose_parser)
     gen = build_generator(
@@ -145,6 +148,7 @@ def build_parser_and_generator(
         compile_extension,
         verbose_c_extension,
         keep_asserts_in_extension,
+        skip_actions=skip_actions,
     )
 
     return grammar, parser, tokenizer, gen

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -29,28 +29,36 @@ EXTENSION_PREFIX = """\
 """
 EXTENSION_SUFFIX = """
 static PyObject *
-parse_file(PyObject *self, PyObject *args)
+parse_file(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static const char *keywords[] = {"file", "mode", NULL};
     const char *filename;
+    int mode = %(mode)s;
 
-    if (!PyArg_ParseTuple(args, "s", &filename))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i", keywords, &filename, &mode))
         return NULL;
-    return run_parser_from_file(filename, (void *)start_rule, %(mode)s);
+    if (mode < 0 || mode > %(mode)s)
+        return PyErr_Format(PyExc_ValueError, "Bad mode, must be 0 <= mode <= %(mode)s");
+    return run_parser_from_file(filename, (void *)start_rule, mode);
 }
 
 static PyObject *
-parse_string(PyObject *self, PyObject *args)
+parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static const char *keywords[] = {"string", "mode", NULL};
     const char *the_string;
+    int mode = %(mode)s;
 
-    if (!PyArg_ParseTuple(args, "s", &the_string))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i", keywords, &the_string, &mode))
         return NULL;
-    return run_parser_from_string(the_string, (void *)start_rule, %(mode)s);
+    if (mode < 0 || mode > %(mode)s)
+        return PyErr_Format(PyExc_ValueError, "Bad mode, must be 0 <= mode <= %(mode)s");
+    return run_parser_from_string(the_string, (void *)start_rule, mode);
 }
 
 static PyMethodDef ParseMethods[] = {
-    {"parse_file",  parse_file, METH_VARARGS, "Parse a file."},
-    {"parse_string",  parse_string, METH_VARARGS, "Parse a string."},
+    {"parse_file",  parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
+    {"parse_string",  parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -453,7 +453,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 )
             self.print(f"res = {names[0]};")
 
-    def emit_no_action(self) -> None:
+    def emit_dummy_action(self) -> None:
         self.print(f"res = CONSTRUCTOR(p);")
 
     def handle_alt_normal(self, node: Alt, is_gather: bool, names: List[str]) -> None:
@@ -464,7 +464,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             # Prepare to emmit the rule action and do so
             self._set_up_token_end_metadata_extraction()
             if self.skip_actions:
-                self.emit_no_action()
+                self.emit_dummy_action()
             elif node.action:
                 self.emit_action(node)
             else:
@@ -485,7 +485,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             # Prepare to emit the rule action and do so
             self._set_up_token_end_metadata_extraction()
             if self.skip_actions:
-                self.emit_no_action()
+                self.emit_dummy_action()
             elif node.action:
                 self.emit_action(node)
             else:

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -31,7 +31,7 @@ EXTENSION_SUFFIX = """
 static PyObject *
 parse_file(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    static const char *keywords[] = {"file", "mode", NULL};
+    static char *keywords[] = {"file", "mode", NULL};
     const char *filename;
     int mode = %(mode)s;
 
@@ -45,7 +45,7 @@ parse_file(PyObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    static const char *keywords[] = {"string", "mode", NULL};
+    static char *keywords[] = {"string", "mode", NULL};
     const char *the_string;
     int mode = %(mode)s;
 
@@ -57,8 +57,8 @@ parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyMethodDef ParseMethods[] = {
-    {"parse_file",  parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
-    {"parse_string",  parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
+    {"parse_file", (PyCFunction)parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
+    {"parse_string",  (PyCFunction)parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -144,7 +144,7 @@ CONSTRUCTOR(Parser *p, ...)
     if (!id) {
         return NULL;
     }
-    cache = Name(id, Load, 1, 0, 1, 0,p->arena);
+    cache = Name(id, Load, 1, 0, 1, 0, p->arena);
     return cache;
 }
 

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -135,12 +135,17 @@ update_memo(Parser *p, int mark, int type, void *node)
 void *
 CONSTRUCTOR(Parser *p, ...)
 {
+    static void *cache = NULL;
+
+    if (cache != NULL)
+        return cache;
 
     PyObject *id = _create_dummy_identifier(p);
     if (!id) {
         return NULL;
     }
-    return Name(id, Load, 1, 0, 1, 0,p->arena);
+    cache = Name(id, Load, 1, 0, 1, 0,p->arena);
+    return cache;
 }
 
 int

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -36,6 +36,11 @@ argparser.add_argument(
 argparser.add_argument(
     "-v", "--verbose", action="store_true", help="Display detailed errors for failures"
 )
+argparser.add_argument(
+    "--skip-actions",
+    action="store_true",
+    help="Don't generate action code (not even default actions)",
+)
 argparser.add_argument("-t", "--tree", action="count", help="Compare parse tree to official AST")
 
 
@@ -121,7 +126,12 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            build_parser_and_generator(grammar_file, "pegen/parse.c", True)
+            build_parser_and_generator(
+                grammar_file,
+                "pegen/parse.c",
+                compile_extension=True,
+                skip_actions=args.skip_actions,
+            )
         except Exception as err:
             print(
                 f"{FAIL}The following error occurred when generating the parser. Please check your grammar file.\n{ENDC}",


### PR DESCRIPTION
Fixes #160 (including the "extra credit" idea of adding another flag to force `mode = 0`).