### PR TITLE
By default, compile to bytecode rather than to AST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,39 @@ regen-metaparser: pegen/metagrammar.gram pegen/*.py
 # this has different names in different systems so we are abusing the implicit dependency on
 # parse.c by the use of --compile-extension.
 
-test: pegen/parse.c
-	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)'); exec(compile(t, '', 'exec'))"
+.PHONY: test
+
+test: run
+
+run: pegen/parse.c
+	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)'); exec(t)"
 
 compile: pegen/parse.c
-	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)')"
+	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)', mode=2)"
 
-time: pegen/parse.c
-	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse_file('$(TIMEFILE)')"
+parse: pegen/parse.c
+	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)', mode=1)"
 
-time_stdlib:
+check: pegen/parse.c
+	$(PYTHON) -c "from pegen import parse; t = parse.parse_file('$(TESTFILE)', mode=0)"
+
+time: time_compile
+
+time_compile: pegen/parse.c
+	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse_file('$(TIMEFILE)', mode=2)"
+
+time_parse: pegen/parse.c
+	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse_file('$(TIMEFILE)', mode=1)"
+
+time_check: pegen/parse.c
+	/usr/bin/time -l $(PYTHON) -c "from pegen import parse; parse.parse_file('$(TIMEFILE)', mode=0)"
+
+time_stdlib: time_stdlib_compile
+
+time_stdlib_compile:
+	/usr/bin/time -l $(PYTHON) -c "import ast; compile(open('$(TIMEFILE)').read(), '$(TIMEFILE)', 'exec')"
+
+time_stdlib_parse:
 	/usr/bin/time -l $(PYTHON) -c "import ast; ast.parse(open('$(TIMEFILE)').read())"
 
 simpy:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= `/usr/bin/which python3.8`
 CPYTHON ?= "./cpython"
 MYPY ?= `/usr/bin/which mypy`
 
-GRAMMAR = data/cprog.gram
+GRAMMAR = data/simpy.gram
 TESTFILE = data/cprog.txt
 TIMEFILE = data/xxl.txt
 TESTDIR = .
@@ -18,7 +18,7 @@ clean:
 
 dump: pegen/parse.c
 	cat -n $(TESTFILE)
-	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse_file('$(TESTFILE)'); print(ast.dump(t))"
+	$(PYTHON) -c "from pegen import parse; import ast; t = parse.parse_file('$(TESTFILE)', mode=1); print(ast.dump(t))"
 
 regen-metaparser: pegen/metagrammar.gram pegen/*.py
 	$(PYTHON) -m pegen -q -c pegen/metagrammar.gram -o pegen/grammar_parser.py

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -1,5 +1,7 @@
 # Simplified grammar for Python
 
+@bytecode True
+
 start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
 statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
 

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -46,6 +46,11 @@ argparser.add_argument("filename", help="Grammar description")
 argparser.add_argument(
     "--optimized", action="store_true", help="Compile the extension in optimized mode"
 )
+argparser.add_argument(
+    "--skip-actions",
+    action="store_true",
+    help="Don't generate action code (not even default actions)",
+)
 
 
 def main() -> None:
@@ -71,6 +76,7 @@ def main() -> None:
             verbose_parser,
             args.verbose,
             keep_asserts_in_extension=False if args.optimized else True,
+            skip_actions=args.skip_actions,
         )
     except Exception as err:
         if args.verbose:

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -47,9 +47,7 @@ argparser.add_argument(
     "--optimized", action="store_true", help="Compile the extension in optimized mode"
 )
 argparser.add_argument(
-    "--skip-actions",
-    action="store_true",
-    help="Don't generate action code (not even default actions)",
+    "--skip-actions", action="store_true", help="Suppress code emission for rule actions",
 )
 
 

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -137,7 +137,7 @@ def build_parser_and_generator(
           output when compiling the C extension . Defaults to False.
         keep_asserts_in_extension (bool, optional): Whether to keep the assert statements
           when compiling the extension module. Defaults to True.
-        skip_actions (boo, optional): Whether to pretend no rule has any actions.
+        skip_actions (bool, optional): Whether to pretend no rule has any actions.
     """
     grammar, parser, tokenizer = build_parser(grammar_file, verbose_tokenizer, verbose_parser)
     gen = build_generator(

--- a/pegen/build.py
+++ b/pegen/build.py
@@ -92,13 +92,14 @@ def build_generator(
     compile_extension: bool = False,
     verbose_c_extension: bool = False,
     keep_asserts_in_extension: bool = True,
+    skip_actions: bool = False,
 ) -> ParserGenerator:
     with open(output_file, "w") as file:
         gen: ParserGenerator
         if output_file.endswith(".c"):
-            gen = CParserGenerator(grammar, file)
+            gen = CParserGenerator(grammar, file, skip_actions=skip_actions)
         elif output_file.endswith(".py"):
-            gen = PythonParserGenerator(grammar, file)
+            gen = PythonParserGenerator(grammar, file)  # TODO: skip_actions
         else:
             raise Exception("Your output file must either be a .c or .py file")
         gen.generate(grammar_file)
@@ -119,6 +120,7 @@ def build_parser_and_generator(
     verbose_parser: bool = False,
     verbose_c_extension: bool = False,
     keep_asserts_in_extension: bool = True,
+    skip_actions: bool = False,
 ) -> Tuple[Grammar, Parser, Tokenizer, ParserGenerator]:
     """Generate rules, parser, tokenizer, parser generator for a given grammar
 
@@ -135,6 +137,7 @@ def build_parser_and_generator(
           output when compiling the C extension . Defaults to False.
         keep_asserts_in_extension (bool, optional): Whether to keep the assert statements
           when compiling the extension module. Defaults to True.
+        skip_actions (boo, optional): Whether to pretend no rule has any actions.
     """
     grammar, parser, tokenizer = build_parser(grammar_file, verbose_tokenizer, verbose_parser)
     gen = build_generator(
@@ -145,6 +148,7 @@ def build_parser_and_generator(
         compile_extension,
         verbose_c_extension,
         keep_asserts_in_extension,
+        skip_actions=skip_actions,
     )
 
     return grammar, parser, tokenizer, gen

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -29,28 +29,36 @@ EXTENSION_PREFIX = """\
 """
 EXTENSION_SUFFIX = """
 static PyObject *
-parse_file(PyObject *self, PyObject *args)
+parse_file(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static const char *keywords[] = {"file", "mode", NULL};
     const char *filename;
+    int mode = %(mode)s;
 
-    if (!PyArg_ParseTuple(args, "s", &filename))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i", keywords, &filename, &mode))
         return NULL;
-    return run_parser_from_file(filename, (void *)start_rule, %(mode)s);
+    if (mode < 0 || mode > %(mode)s)
+        return PyErr_Format(PyExc_ValueError, "Bad mode, must be 0 <= mode <= %(mode)s");
+    return run_parser_from_file(filename, (void *)start_rule, mode);
 }
 
 static PyObject *
-parse_string(PyObject *self, PyObject *args)
+parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static const char *keywords[] = {"string", "mode", NULL};
     const char *the_string;
+    int mode = %(mode)s;
 
-    if (!PyArg_ParseTuple(args, "s", &the_string))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i", keywords, &the_string, &mode))
         return NULL;
-    return run_parser_from_string(the_string, (void *)start_rule, %(mode)s);
+    if (mode < 0 || mode > %(mode)s)
+        return PyErr_Format(PyExc_ValueError, "Bad mode, must be 0 <= mode <= %(mode)s");
+    return run_parser_from_string(the_string, (void *)start_rule, mode);
 }
 
 static PyMethodDef ParseMethods[] = {
-    {"parse_file",  parse_file, METH_VARARGS, "Parse a file."},
-    {"parse_string",  parse_string, METH_VARARGS, "Parse a string."},
+    {"parse_file",  parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
+    {"parse_string",  parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -256,6 +256,8 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             mode = 0
         else:
             mode = int(self.rules["start"].type == "mod_ty")
+            if mode == 1:
+                mode += 1
         modulename = self.grammar.metas.get("modulename", "parse")
         trailer = self.grammar.metas.get("trailer", EXTENSION_SUFFIX)
         if trailer:

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -453,7 +453,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 )
             self.print(f"res = {names[0]};")
 
-    def emit_no_action(self) -> None:
+    def emit_dummy_action(self) -> None:
         self.print(f"res = CONSTRUCTOR(p);")
 
     def handle_alt_normal(self, node: Alt, is_gather: bool, names: List[str]) -> None:
@@ -464,7 +464,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             # Prepare to emmit the rule action and do so
             self._set_up_token_end_metadata_extraction()
             if self.skip_actions:
-                self.emit_no_action()
+                self.emit_dummy_action()
             elif node.action:
                 self.emit_action(node)
             else:
@@ -485,7 +485,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             # Prepare to emit the rule action and do so
             self._set_up_token_end_metadata_extraction()
             if self.skip_actions:
-                self.emit_no_action()
+                self.emit_dummy_action()
             elif node.action:
                 self.emit_action(node)
             else:

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -256,7 +256,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             mode = 0
         else:
             mode = int(self.rules["start"].type == "mod_ty")
-            if mode == 1:
+            if mode == 1 and self.grammar.metas.get("bytecode"):
                 mode += 1
         modulename = self.grammar.metas.get("modulename", "parse")
         trailer = self.grammar.metas.get("trailer", EXTENSION_SUFFIX)

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -31,7 +31,7 @@ EXTENSION_SUFFIX = """
 static PyObject *
 parse_file(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    static const char *keywords[] = {"file", "mode", NULL};
+    static char *keywords[] = {"file", "mode", NULL};
     const char *filename;
     int mode = %(mode)s;
 
@@ -45,7 +45,7 @@ parse_file(PyObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    static const char *keywords[] = {"string", "mode", NULL};
+    static char *keywords[] = {"string", "mode", NULL};
     const char *the_string;
     int mode = %(mode)s;
 
@@ -57,8 +57,8 @@ parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyMethodDef ParseMethods[] = {
-    {"parse_file",  parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
-    {"parse_string",  parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
+    {"parse_file", (PyCFunction)parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
+    {"parse_string",  (PyCFunction)parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -144,7 +144,7 @@ CONSTRUCTOR(Parser *p, ...)
     if (!id) {
         return NULL;
     }
-    cache = Name(id, Load, 1, 0, 1, 0,p->arena);
+    cache = Name(id, Load, 1, 0, 1, 0, p->arena);
     return cache;
 }
 

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -135,12 +135,17 @@ update_memo(Parser *p, int mark, int type, void *node)
 void *
 CONSTRUCTOR(Parser *p, ...)
 {
+    static void *cache = NULL;
+
+    if (cache != NULL)
+        return cache;
 
     PyObject *id = _create_dummy_identifier(p);
     if (!id) {
         return NULL;
     }
-    return Name(id, Load, 1, 0, 1, 0,p->arena);
+    cache = Name(id, Load, 1, 0, 1, 0,p->arena);
+    return cache;
 }
 
 int

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -468,8 +468,10 @@ run_parser(struct tok_state* tok, void *(start_rule_func)(Parser *), int mode)
         goto exit;
     }
 
-    if (mode == 1) {
-        result =  PyAST_mod2obj(res);
+    if (mode == 2) {
+        result = (PyObject *)PyAST_CompileObject(res, tok->filename, NULL, -1, p->arena);
+    } else if (mode == 1) {
+        result = PyAST_mod2obj(res);
     } else {
         result = Py_None;
         Py_INCREF(result);

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -36,6 +36,11 @@ argparser.add_argument(
 argparser.add_argument(
     "-v", "--verbose", action="store_true", help="Display detailed errors for failures"
 )
+argparser.add_argument(
+    "--skip-actions",
+    action="store_true",
+    help="Don't generate action code (not even default actions)",
+)
 argparser.add_argument("-t", "--tree", action="count", help="Compare parse tree to official AST")
 
 
@@ -121,7 +126,12 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            build_parser_and_generator(grammar_file, "pegen/parse.c", True)
+            build_parser_and_generator(
+                grammar_file,
+                "pegen/parse.c",
+                compile_extension=True,
+                skip_actions=args.skip_actions,
+            )
         except Exception as err:
             print(
                 f"{FAIL}The following error occurred when generating the parser. Please check your grammar file.\n{ENDC}",

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -37,9 +37,7 @@ argparser.add_argument(
     "-v", "--verbose", action="store_true", help="Display detailed errors for failures"
 )
 argparser.add_argument(
-    "--skip-actions",
-    action="store_true",
-    help="Don't generate action code (not even default actions)",
+    "--skip-actions", action="store_true", help="Suppress code emission for rule actions",
 )
 argparser.add_argument("-t", "--tree", action="count", help="Compare parse tree to official AST")
 

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -170,7 +170,7 @@ def main() -> None:
 
         if not should_exclude_file:
             try:
-                tree = parse.parse_file(file)
+                tree = parse.parse_file(file, mode=1)
                 if args.tree:
                     trees[file] = tree
                 if not args.short:

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -488,7 +488,7 @@ def parser_extension(tmp_path_factory: Any) -> Any:
 
 @pytest.mark.parametrize("source", TEST_SOURCES, ids=TEST_IDS)
 def test_correct_ast_generation_on_source_files(parser_extension: Any, source: str) -> None:
-    actual_ast = parser_extension.parse_string(source)
+    actual_ast = parser_extension.parse_string(source, mode=1)
     expected_ast = ast.parse(source)
     assert ast.dump(actual_ast, include_attributes=True) == ast.dump(
         expected_ast, include_attributes=True
@@ -498,13 +498,13 @@ def test_correct_ast_generation_on_source_files(parser_extension: Any, source: s
 @pytest.mark.parametrize("source", FAIL_SOURCES, ids=FAIL_TEST_IDS)
 def test_incorrect_ast_generation_on_source_files(parser_extension: Any, source: str) -> None:
     with pytest.raises(SyntaxError):
-        parser_extension.parse_string(source)
+        parser_extension.parse_string(source, mode=0)
 
 
 @pytest.mark.xfail
 def test_ast_generation_for_fstrings(parser_extension: Any) -> None:
     source = "f'{val}'"
-    actual_ast = parser_extension.parse_string(source)
+    actual_ast = parser_extension.parse_string(source, mode=1)
     expected_ast = ast.parse(source)
     assert ast.dump(actual_ast, include_attributes=True) == ast.dump(
         expected_ast, include_attributes=True


### PR DESCRIPTION
Use mode=1 to return an AST, or mode=0 to return None.

Note that mode=1 is actually the slowest, since it has to convert the
internal AST to an ast.AST tree. mode=0 is the fastest (it creates an
internal AST and then throws it away).  mode=2 is the most realistic,
since this is what import does when loading a module for which no .pyc
file exists.

~This reveals that compiling data/xxl.txt this way is actually faster
than the stdlib compile() function!~
```
make time_stdlib: 1.36 real, 1.09 user, 0.26 sys (median of three)
make time:        0.90 real, 0.68 user, 0.20 sys (median of three). # Never mind, see next comment
```
Also, a run of `make simpy_cpython` now says:
```
Checked 1,641 files, 749,570 lines, 27,622,497 bytes in 6.700 seconds.
That's 111,883 lines/sec, or 4,123,014 bytes/sec.
```
