### PR TITLE
Refactor and simplify string token handling and parse them correctly in all grammars

### DIFF
--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -395,7 +395,7 @@ string_token(Parser *p)
         return NULL;
     }
 
-    char *the_str = PyBytes_AsString(t->bytes) ;
+    char *the_str = PyBytes_AsString(t->bytes);
     if (the_str == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Closes: #163 

Apart from simplifying things a bit, this PR makes sure that `string_token` *always* produces valid AST string nodes (`Constant`) with the appropriate string types. Then, in `concatenate_strings` we just add them together (if the types are correct) but we don't do any more parsing, which arguably is a better split of responsibilities between the functions.