### PR TITLE
Add formatting targets to the makefile

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+# A clang-format style that approximates Python's PEP 7
+BasedOnStyle: Google
+AlwaysBreakAfterReturnType: All
+AllowShortIfStatementsOnASingleLine: false
+AlignAfterOpenBracket: Align
+BreakBeforeBraces: Stroustrup
+ColumnLimit: 95
+DerivePointerAlignment: false
+IndentWidth: 4
+Language: Cpp
+PointerAlignment: Right
+ReflowComments: true
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+TabWidth: 4
+UseTab: Never
+SortIncludes: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,15 @@ matrix:
       script:
           - make mypy
 
+    - name: "black"
+      script:
+          - python -m black pegen tatsu test scripts --check
+
     - name: "pytest"
       script:
           - python -m pytest -v --cov=pegen --cov-report term
       after_success:
           - coveralls
-
 
     - name: "makefile_targets"
       script:

--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,21 @@ bench: cpython
 	$(MAKE) -s simpy_cpython 2>/dev/null
 	$(MAKE) -s simpy_cpython 2>/dev/null
 
+# To install clang-format:
+#    on mac: "brew install clang-format"
+#    on ubuntu: "apt-get install clang-format"
+#    on arch: "pacman -S clang"
 format-c:
 	clang-format pegen/pegen.c -i
 
+# To install clang-tidy:
+#    on mac:
+#       "brew install llvm"
+#       Then, create symlinks to the binaries. For example:
+#       ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"
+#       ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+#    on ubuntu: "apt-get install clang-tidy"
+#    on arch: "pacman -S clang"
 clang-tidy:
 	$(eval COMPILE_OPTIONS = $(shell python-config --cflags))
 	clang-tidy pegen/pegen.c -fix-errors -fix -checks="readability-braces-around-statements" -- $(COMPILE_OPTIONS) 1>/dev/null

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,13 @@ bench: cpython
 	$(MAKE) -s simpy_cpython 2>/dev/null
 	$(MAKE) -s simpy_cpython 2>/dev/null
 
+format-pegen:
+	$(eval COMPILE_OPTIONS = $(shell python-config --cflags))
+	clang-tidy pegen/pegen.c -fix-errors -fix -checks="readability-braces-around-statements" -- $(COMPILE_OPTIONS) 1>/dev/null
+	clang-format pegen/pegen.c -i
+
+format: black format-pegen
+
 find_max_nesting:
 	$(PYTHON) scripts/find_max_nesting.py
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ clean-cpython:
 mypy: regen-metaparser
 	$(MYPY)  # For list of files, see mypy.ini
 
-black:
+format-python:
 	black pegen tatsu test scripts
 
 bench: cpython
@@ -101,12 +101,14 @@ bench: cpython
 	$(MAKE) -s simpy_cpython 2>/dev/null
 	$(MAKE) -s simpy_cpython 2>/dev/null
 
-format-pegen:
-	$(eval COMPILE_OPTIONS = $(shell python-config --cflags))
-	clang-tidy pegen/pegen.c -fix-errors -fix -checks="readability-braces-around-statements" -- $(COMPILE_OPTIONS) 1>/dev/null
+format-c:
 	clang-format pegen/pegen.c -i
 
-format: black format-pegen
+clang-tidy:
+	$(eval COMPILE_OPTIONS = $(shell python-config --cflags))
+	clang-tidy pegen/pegen.c -fix-errors -fix -checks="readability-braces-around-statements" -- $(COMPILE_OPTIONS) 1>/dev/null
+
+format: format-python format-c
 
 find_max_nesting:
 	$(PYTHON) scripts/find_max_nesting.py

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -196,7 +196,7 @@ fill_token(Parser *p)
     }
 
     Token *t = p->tokens[p->fill];
-    t->type = (type == NAME) ? _get_keyword_or_name_type(p, start, (int) (end - start)) : type;
+    t->type = (type == NAME) ? _get_keyword_or_name_type(p, start, (int)(end - start)) : type;
     t->bytes = PyBytes_FromStringAndSize(start, end - start);
     if (t->bytes == NULL) {
         return -1;
@@ -506,11 +506,8 @@ keyword_token(Parser *p, const char *val)
 }
 
 PyObject *
-run_parser(struct tok_state *tok,
-           void *(start_rule_func)(Parser *),
-           int mode,
-           KeywordToken **keywords,
-           int n_keyword_lists)
+run_parser(struct tok_state *tok, void *(start_rule_func)(Parser *), int mode,
+           KeywordToken **keywords, int n_keyword_lists)
 {
     PyObject *result = NULL;
     Parser *p = PyMem_Malloc(sizeof(Parser));
@@ -590,11 +587,8 @@ exit:
 }
 
 PyObject *
-run_parser_from_file(const char *filename,
-                     void *(start_rule_func)(Parser *),
-                     int mode,
-                     KeywordToken **keywords,
-                     int n_keyword_lists)
+run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode,
+                     KeywordToken **keywords, int n_keyword_lists)
 {
     FILE *fp = fopen(filename, "rb");
     if (fp == NULL) {
@@ -630,11 +624,8 @@ error:
 }
 
 PyObject *
-run_parser_from_string(const char *str,
-                       void *(start_rule_func)(Parser *),
-                       int mode,
-                       KeywordToken **keywords,
-                       int n_keyword_lists)
+run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int mode,
+                       KeywordToken **keywords, int n_keyword_lists)
 {
     struct tok_state *tok = PyTokenizer_FromString(str, 1);
 

--- a/test/test_first_sets.py
+++ b/test/test_first_sets.py
@@ -236,5 +236,5 @@ def test_multiple_nullable_rules() -> None:
         "thing": {"'+'", ""},
         "start": {"'+'", "'-'", "'*'"},
         "other": {"'*'"},
-        "another": {"'/'"}
+        "another": {"'/'"},
     }


### PR DESCRIPTION
As requested by @lysnikolaou , add one target that allows formatting pegen/pegen.c (requires
clang-format and clang-tidy) available on the system and another target
that formats everything (Python and C files).

Feel free to suggest tweaks to the C file or if you want additional files to be formatted.