### PR TITLE
Generate different token type for each keyword

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -360,6 +360,9 @@ atom[expr_ty]:
     | setcomp
     | dict
     | dictcomp
+    | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
+    | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
+    | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
     | NAME
     | a=STRING+ { concatenate_strings(p, a) }
     | NUMBER

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -99,12 +99,9 @@ class CCallMakerVisitor(GrammarVisitor):
         if name in ("NAME", "NUMBER", "STRING"):
             name = name.lower()
             return f"{name}_var", f"{name}_token(p)"
-        if name in ("NEWLINE", "DEDENT", "INDENT", "ENDMARKER"):
+        if name in ("NEWLINE", "DEDENT", "INDENT", "ENDMARKER", "ASYNC", "AWAIT"):
             name = name.lower()
             return f"{name}_var", f"{name}_token(p)"
-        if name in ("ASYNC", "AWAIT"):
-            name = name.lower()
-            return self.keyword_helper(name)
         return f"{name}_var", f"{name}_rule(p)"
 
     def visit_StringLeaf(self, node: StringLeaf) -> Tuple[str, str]:
@@ -191,7 +188,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         skip_actions: bool = False,
     ):
         super().__init__(grammar, file)
-        self.callmakervisitor = CCallMakerVisitor(self)
+        self.callmakervisitor: CCallMakerVisitor = CCallMakerVisitor(self)
         self._varname_counter = 0
         self.debug = debug
         self.skip_actions = skip_actions

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -109,7 +109,7 @@ class CCallMakerVisitor(GrammarVisitor):
 
     def visit_StringLeaf(self, node: StringLeaf) -> Tuple[str, str]:
         val = ast.literal_eval(node.value)
-        if re.match(r"[a-zA-Z_]\w*\Z", val): # This is a keyword
+        if re.match(r"[a-zA-Z_]\w*\Z", val):  # This is a keyword
             return self.keyword_helper(val)
         else:
             assert val in exact_token_types, f"{node.value} is not a known literal"
@@ -273,7 +273,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         if trailer:
             self.print(trailer.rstrip("\n") % dict(mode=mode, modulename=modulename))
 
-    def _setup_keywords(self):
+    def _setup_keywords(self) -> None:
         self.print("static KeywordToken keywords[] = {")
         with self.indent():
             for keyword_str, keyword_type in self.callmakervisitor.keyword_cache.items():
@@ -415,7 +415,9 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.print("{")
         if node.name.startswith("start"):
             with self.indent():
-                self.print(f"init_keywords(p, &keywords, {len(self.callmakervisitor.keyword_cache)});")
+                self.print(
+                    f"init_keywords(p, &keywords, {len(self.callmakervisitor.keyword_cache)});"
+                )
         if is_loop:
             self._handle_loop_rule_body(node, rhs)
         else:

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -47,6 +47,7 @@ class ParserGenerator:
         self.first_graph, self.first_sccs = compute_left_recursives(self.rules)
         self.todo = self.rules.copy()  # Rules to generate
         self.counter = 0  # For name_rule()/name_loop()
+        self.keyword_counter = 499  # For keyword_type()
 
     @abstractmethod
     def generate(self, filename: str) -> None:
@@ -81,6 +82,10 @@ class ParserGenerator:
             for rulename in todo:
                 self.todo[rulename].collect_todo(self)
             done = alltodo
+
+    def keyword_type(self):
+        self.keyword_counter += 1
+        return self.keyword_counter
 
     def name_node(self, rhs: Rhs) -> str:
         self.counter += 1

--- a/pegen/parser_generator.py
+++ b/pegen/parser_generator.py
@@ -83,7 +83,7 @@ class ParserGenerator:
                 self.todo[rulename].collect_todo(self)
             done = alltodo
 
-    def keyword_type(self):
+    def keyword_type(self) -> int:
         self.keyword_counter += 1
         return self.keyword_counter
 

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -201,9 +201,7 @@ fill_token(Parser *p)
     }
 
     Token *t = p->tokens[p->fill];
-    t->type = (type == NAME || type == ASYNC || type == AWAIT)
-              ? _get_keyword_or_name_type(p, start, end - start)
-              : type;
+    t->type = (type == NAME) ? _get_keyword_or_name_type(p, start, end - start) : type;
     t->bytes = PyBytes_FromStringAndSize(start, end - start);
     if (t->bytes == NULL) {
         return -1;
@@ -315,6 +313,18 @@ get_last_nonnwhitespace_token(Parser *p)
         }
     }
     return token;
+}
+
+void *
+async_token(Parser *p)
+{
+    return expect_token(p, ASYNC);
+}
+
+void *
+await_token(Parser *p)
+{
+    return expect_token(p, AWAIT);
 }
 
 void *

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -158,6 +158,8 @@ _get_keyword_or_name_type(Parser *p, char *name, size_t name_len)
 {
     for (int i = 0; i < p->n_keywords; i++) {
         KeywordToken k = (*p->keywords)[i];
+        // The length comparison is needed duo to name containing
+        // the whole input starting from the current token
         if (k.str[0] == name[0]
             && strlen(k.str) == name_len
             && strncmp(k.str, name, name_len) == 0) {

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -19,11 +19,18 @@ typedef struct {
 } Token;
 
 typedef struct {
+    char *str;
+    int type;
+} KeywordToken;
+
+typedef struct {
     struct tok_state *tok;
     Token **tokens;
     int mark;
     int fill, size;
     PyArena *arena;
+    KeywordToken (*keywords)[];
+    int n_keywords;
 } Parser;
 
 typedef struct {
@@ -69,11 +76,10 @@ int lookahead_with_string(int, void *(func)(Parser *, const char *), Parser *, c
 int lookahead_with_int(int, Token *(func)(Parser *, int), Parser *, int);
 int lookahead(int, void *(func)(Parser *), Parser *);
 
+void init_keywords(Parser *p, KeywordToken (*keywords_list)[], int n);
 Token *expect_token(Parser *p, int type);
 Token *get_last_nonnwhitespace_token(Parser *);
 int fill_token(Parser *p);
-void *async_token(Parser *p);
-void *await_token(Parser *p);
 void *endmarker_token(Parser *p);
 expr_ty name_token(Parser *p);
 void *newline_token(Parser *p);

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -76,7 +76,6 @@ int lookahead_with_string(int, void *(func)(Parser *, const char *), Parser *, c
 int lookahead_with_int(int, Token *(func)(Parser *, int), Parser *, int);
 int lookahead(int, void *(func)(Parser *), Parser *);
 
-void init_keywords(Parser *p, KeywordToken (*keywords_list)[], int n);
 Token *expect_token(Parser *p, int type);
 Token *get_last_nonnwhitespace_token(Parser *);
 int fill_token(Parser *p);
@@ -98,8 +97,16 @@ void *CONSTRUCTOR(Parser *p, ...);
 #define EXTRA_EXPR(head, tail) head->lineno, head->col_offset, tail->end_lineno, tail->end_col_offset, p->arena
 #define EXTRA start_lineno, start_col_offset, end_lineno, end_col_offset, p->arena
 
-PyObject *run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode);
-PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int mode);
+PyObject *run_parser_from_file(const char *filename,
+                               void *(start_rule_func)(Parser *),
+                               int mode,
+                               KeywordToken (*keywords_list)[],
+                               int n_keywords);
+PyObject *run_parser_from_string(const char *str,
+                                 void *(start_rule_func)(Parser *),
+                                 int mode,
+                                 KeywordToken (*keywords_list)[],
+                                 int n_keywords);
 asdl_seq *singleton_seq(Parser *, void *);
 asdl_seq *seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *seq_flatten(Parser *, asdl_seq *);

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -80,6 +80,8 @@ void init_keywords(Parser *p, KeywordToken (*keywords_list)[], int n);
 Token *expect_token(Parser *p, int type);
 Token *get_last_nonnwhitespace_token(Parser *);
 int fill_token(Parser *p);
+void *async_token(Parser *p);
+void *await_token(Parser *p);
 void *endmarker_token(Parser *p);
 expr_ty name_token(Parser *p);
 void *newline_token(Parser *p);

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -19,6 +19,9 @@ TEST_CASES = [
     ('annotation_with_parens', '(parens): int'),
     ('assert', 'assert a'),
     ('assert_message', 'assert a, b'),
+    ('assignment_false', 'a = False'),
+    ('assignment_none', 'a = None'),
+    ('assignment_true', 'a = True'),
     ('asyncfor',
      '''
         async for i in a:
@@ -249,7 +252,10 @@ TEST_CASES = [
         pass; pass
         pass
      '''),
-    ('namedexpr', '(x:=[1, 2, 3])'),
+    ('namedexpr', '(x := [1, 2, 3])'),
+    ('namedexpr_false', '(x := False)'),
+    ('namedexpr_none', '(x := None)'),
+    ('namedexpr_true', '(x := True)'),
     ('nonlocal', 'nonlocal a, b'),
     ('pass', 'pass'),
     ('pos_args',
@@ -430,6 +436,7 @@ TEST_CASES = [
 ]
 
 FAIL_TEST_CASES = [
+    ("assignment_keyword", "a = if"),
     ("del_call", "del a()"),
     ("del_call_genexp", "del a(i for i in b)"),
     ("del_subscript_call", "del a[b]()"),


### PR DESCRIPTION
This way we can correctly handle parsing keywords. This includes:
    * Throwing an exception if a keyword is used as a NAME
    * Generating correct nodes for True, False, None

Closes #152.

PS: Mypy is not happy for some reason. Any suggestions on what to do to get rid of the errors?