### PR TITLE
Rearrange alternatives in grammar

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -10,6 +10,8 @@ simple_stmt[asdl_seq*]: a=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else the parser will get stuck;
 # but it must follow all others, else reserved words will match a simple NAME.
 small_stmt[stmt_ty]:
+    | assignment
+    | e=expressions { _Py_Expr(e, EXTRA) }
     | return_stmt
     | import_stmt
     | pass_stmt
@@ -21,8 +23,6 @@ small_stmt[stmt_ty]:
     | nonlocal_stmt
     | break_stmt
     | continue_stmt
-    | assignment
-    | e=expressions { _Py_Expr(e, EXTRA) }
 compound_stmt[stmt_ty]: if_stmt | while_stmt | for_stmt | with_stmt | try_stmt | function_def | class_def
 
 # NOTE: yield_expression may start with 'yield'; yield_expr must start with 'yield'
@@ -195,7 +195,7 @@ class_def_raw[stmt_ty]:
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
 
-block[asdl_seq*]: simple_stmt | NEWLINE INDENT a=statements DEDENT { a }
+block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
 
 expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
 expressions[expr_ty]:
@@ -216,9 +216,9 @@ named_expression[expr_ty]:
     | expression
 yield_expression: yield_expr | expression
 expression[expr_ty]:
-    | lambdef
     | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
     | disjunction
+    | lambdef
 
 lambdef[expr_ty]:
     | 'lambda' a=[lambda_parameters] ':' b=expression { _Py_Lambda((a) ? a : empty_arguments(p), b, EXTRA) }
@@ -351,21 +351,21 @@ slice[slice_ty]:
     | a=expression { _Py_Index(a, p->arena) }
 # STRING+'s output is just a hack for now 
 atom[expr_ty]:
+    | NAME
+    | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
+    | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
+    | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
+    | a=STRING+ { concatenate_strings(p, a) }
+    | NUMBER
     | list
-    | listcomp
     | tuple
+    | listcomp
+    | dict
+    | dictcomp
     | group
     | genexp
     | set
     | setcomp
-    | dict
-    | dictcomp
-    | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
-    | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
-    | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
-    | NAME
-    | a=STRING+ { concatenate_strings(p, a) }
-    | NUMBER
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
 list[expr_ty]:

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -14,16 +14,16 @@ small_stmt[stmt_ty]:
     | e=expressions { _Py_Expr(e, EXTRA) }
     | return_stmt
     | import_stmt
-    | pass_stmt
     | raise_stmt
+    | pass_stmt
+    | del_stmt
     | yield_stmt
     | assert_stmt
-    | del_stmt
-    | global_stmt
-    | nonlocal_stmt
     | break_stmt
     | continue_stmt
-compound_stmt[stmt_ty]: if_stmt | while_stmt | for_stmt | with_stmt | try_stmt | function_def | class_def
+    | global_stmt
+    | nonlocal_stmt
+compound_stmt[stmt_ty]: function_def | if_stmt | class_def | with_stmt | for_stmt | try_stmt | while_stmt
 
 # NOTE: yield_expression may start with 'yield'; yield_expr must start with 'yield'
 assignment:
@@ -328,13 +328,13 @@ await_primary[expr_ty]:
     | primary
 primary[expr_ty]:
     | a=primary '.' b=NAME { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
-    | a=primary b=slicing { _Py_Subscript(a, b, Load, EXTRA) }
     | a=primary b=genexp { _Py_Call(a, singleton_seq(p, b), NULL, EXTRA) }
     | a=primary '(' b=[arguments] ')' {
         _Py_Call(a,
                  (b) ? ((expr_ty) b)->v.Call.args : NULL,
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
+    | a=primary b=slicing { _Py_Subscript(a, b, Load, EXTRA) }
     | atom
 
 slicing[slice_ty]:
@@ -357,14 +357,14 @@ atom[expr_ty]:
     | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
     | a=STRING+ { concatenate_strings(p, a) }
     | NUMBER
-    | list
     | tuple
-    | listcomp
+    | list
     | dict
-    | dictcomp
+    | listcomp
     | group
     | genexp
     | set
+    | dictcomp
     | setcomp
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 


### PR DESCRIPTION
I did some very straightforward rearrangements of alternatives in the grammar, which gave me the following results in `make simpy_cpython`:

Before:
```
Checked 1,658 files, 759,295 lines, 27,977,850 bytes in 12.187 seconds.
That's 62,305 lines/sec, or 2,295,768 bytes/sec.
```

After:
```
Checked 1,658 files, 759,295 lines, 27,977,850 bytes in 7.060 seconds.
That's 107,543 lines/sec, or 3,962,666 bytes/sec.
```

Can you reproduce this?