### PR TITLE
Fix show_parse script after change of default mode

### DIFF
--- a/scripts/show_parse.py
+++ b/scripts/show_parse.py
@@ -93,7 +93,7 @@ def main() -> None:
         build_parser_and_generator(args.grammar_file, "pegen/parse.c", compile_extension=True)
         from pegen.parse import parse_string  # type: ignore[import]
 
-        tree = parse_string(program)
+        tree = parse_string(program, mode=1)
 
         if args.diff:
             a = tree


### PR DESCRIPTION
After changing the default mode when parsing, the mode needs to be
explicitly set to 1 in `parse_string` to get AST objects.

Right now (without this PR) we get:

```
  File "/home/pablogsal/github/python/3.8/Lib/ast.py", line 134, in dump
    raise TypeError('expected AST, got %r' % node.__class__.__name__)
TypeError: expected AST, got 'code'
```