### PR TITLE
Add lookahead to simple_stmt rule

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -363,11 +363,8 @@ atom[expr_ty]:
     | &'[' list
     | &'{' dict
     | &'[' listcomp
-    | &'(' group
-    | &'(' genexp
-    | &'{' set
-    | &'{' dictcomp
-    | &'{' setcomp
+    | &'(' (group | genexp)
+    | &'{' (set | dictcomp | setcomp)
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
 list[expr_ty]:

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -359,12 +359,9 @@ atom[expr_ty]:
     | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
     | &STRING a=STRING+ { concatenate_strings(p, a) }
     | NUMBER
-    | &'(' tuple
-    | &'[' list
-    | &'{' dict
-    | &'[' listcomp
-    | &'(' (group | genexp)
-    | &'{' (set | dictcomp | setcomp)
+    | &'(' (tuple | group | genexp)
+    | &'[' (list | listcomp)
+    | &'{' (dict | set | dictcomp | setcomp)
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
 list[expr_ty]:

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -26,9 +26,9 @@ small_stmt[stmt_ty]:
     | &'global' global_stmt
     | &'nonlocal' nonlocal_stmt
 compound_stmt[stmt_ty]:
-    | &('@' | 'def' | ASYNC) function_def
+    | &('def' | '@' | ASYNC) function_def
     | &'if' if_stmt
-    | &('@' | 'class') class_def
+    | &('class' | '@') class_def
     | &('with' | ASYNC) with_stmt
     | &('for' | ASYNC) for_stmt
     | &'try' try_stmt

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -6,7 +6,9 @@ start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
 statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
 
 statement[asdl_seq*]: a=compound_stmt { singleton_seq(p, a) } | simple_stmt
-simple_stmt[asdl_seq*]: a=';'.small_stmt+ [';'] NEWLINE { a }
+simple_stmt[asdl_seq*]:
+    | a=small_stmt !';' NEWLINE { singleton_seq(p, a) }  # Not needed, there for speedup
+    | a=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else the parser will get stuck;
 # but it must follow all others, else reserved words will match a simple NAME.
 small_stmt[stmt_ty]:
@@ -459,7 +461,7 @@ target[expr_ty]:
 t_primary[expr_ty]:
     | a=t_primary '.' b=NAME &t_lookahead { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
     | a=t_primary b=slicing &t_lookahead { _Py_Subscript(a, b, Load, EXTRA) }
-    | a=t_primary b=genexp  &t_lookahead { _Py_Call(a, singleton_seq(p, b), NULL, EXTRA) }
+    | a=t_primary b=genexp &t_lookahead { _Py_Call(a, singleton_seq(p, b), NULL, EXTRA) }
     | a=t_primary '(' b=[arguments] ')' &t_lookahead {
         _Py_Call(a,
                  (b) ? ((expr_ty) b)->v.Call.args : NULL,

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -14,18 +14,25 @@ simple_stmt[asdl_seq*]:
 small_stmt[stmt_ty]:
     | assignment
     | e=expressions { _Py_Expr(e, EXTRA) }
-    | return_stmt
-    | import_stmt
-    | raise_stmt
-    | pass_stmt
-    | del_stmt
-    | yield_stmt
-    | assert_stmt
-    | break_stmt
-    | continue_stmt
-    | global_stmt
-    | nonlocal_stmt
-compound_stmt[stmt_ty]: function_def | if_stmt | class_def | with_stmt | for_stmt | try_stmt | while_stmt
+    | &'return' return_stmt
+    | &('import' | 'from') import_stmt
+    | &'raise' raise_stmt
+    | 'pass' { _Py_Pass(EXTRA) }
+    | &'del' del_stmt
+    | &'yield' yield_stmt
+    | &'assert' assert_stmt
+    | 'break' { _Py_Break(EXTRA) }
+    | 'continue' { _Py_Continue(EXTRA) }
+    | &'global' global_stmt
+    | &'nonlocal' nonlocal_stmt
+compound_stmt[stmt_ty]:
+    | &('@' | 'def' | ASYNC) function_def
+    | &'if' if_stmt
+    | &('@' | 'class') class_def
+    | &('with' | ASYNC) with_stmt
+    | &('for' | ASYNC) for_stmt
+    | &'try' try_stmt
+    | &'while' while_stmt
 
 # NOTE: yield_expression may start with 'yield'; yield_expr must start with 'yield'
 assignment:
@@ -60,12 +67,6 @@ yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
 assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
 
 del_stmt[stmt_ty]: 'del' a=del_targets { _Py_Delete(a, EXTRA) }
-
-pass_stmt[stmt_ty]: 'pass' { _Py_Pass(EXTRA) }
-
-break_stmt[stmt_ty]: 'break' { _Py_Break(EXTRA) }
-
-continue_stmt[stmt_ty]: 'continue' { _Py_Continue(EXTRA) }
 
 import_stmt[stmt_ty]: import_name | import_from
 import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
@@ -134,8 +135,7 @@ except_block[excepthandler_ty]:
 finally_block[asdl_seq*]: 'finally' ':' a=block { a }
 
 return_stmt[stmt_ty]:
-    | 'return' a=expressions { _Py_Return(a, EXTRA) }
-    | 'return' { _Py_Return(NULL, EXTRA) }
+    | 'return' a=[expressions] { _Py_Return(a, EXTRA) }
 
 raise_stmt[stmt_ty]:
     | 'raise' a=expression b=['from' z=expression { z }] { _Py_Raise(a, b, EXTRA) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -357,17 +357,17 @@ atom[expr_ty]:
     | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
     | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
     | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
-    | a=STRING+ { concatenate_strings(p, a) }
+    | &STRING a=STRING+ { concatenate_strings(p, a) }
     | NUMBER
-    | tuple
-    | list
-    | dict
-    | listcomp
-    | group
-    | genexp
-    | set
-    | dictcomp
-    | setcomp
+    | &'(' tuple
+    | &'[' list
+    | &'{' dict
+    | &'[' listcomp
+    | &'(' group
+    | &'(' genexp
+    | &'{' set
+    | &'{' dictcomp
+    | &'{' setcomp
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
 list[expr_ty]:


### PR DESCRIPTION
Running `simpy_cpython` became approx. 0.8 seconds faster with this. How much of a speedup can you observe?