### PR TITLE
Avoid false SyntaxError's in test_parse_directory 

### DIFF
--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -182,10 +182,15 @@ def parse_directory(
                 if not short:
                     report_status(succeeded=True, file=file, verbose=verbose)
             except Exception as error:
-                report_status(
-                    succeeded=False, file=file, verbose=verbose, error=error, short=short
-                )
-                errors += 1
+                try:
+                    ast.parse(file)
+                except Exception:
+                    pass
+                else:
+                    report_status(
+                        succeeded=False, file=file, verbose=verbose, error=error, short=short
+                    )
+                    errors += 1
             files.append(file)
     t1 = time.time()
 

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -185,7 +185,8 @@ def parse_directory(
                 try:
                     ast.parse(file)
                 except Exception:
-                    pass
+                    if not short:
+                        print(f"File {file} cannot be parsed by either pegen or the ast module.")
                 else:
                     report_status(
                         succeeded=False, file=file, verbose=verbose, error=error, short=short


### PR DESCRIPTION
Don't report invalid syntax errors, when ast.parse cannot parse file either.

When testing PyPI this happens a lot due to Python 2 code.