### PR TITLE
Provide better tracebacks with f-strings

### DIFF
--- a/pegen/parse_string.c
+++ b/pegen/parse_string.c
@@ -555,7 +555,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
         goto exit;
     }
     p2->tok = tok;
-    p2->input_mode = FSTRING_INPUT;
+    p2->input_mode = STRING_INPUT;
     p2->keywords = p->keywords;
     p2->n_keyword_lists = p->n_keyword_lists;
     p2->tokens = PyMem_Malloc(sizeof(Token *));

--- a/pegen/parse_string.c
+++ b/pegen/parse_string.c
@@ -555,7 +555,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
         goto exit;
     }
     p2->tok = tok;
-    p2->input_mode = 2;
+    p2->input_mode = FSTRING_INPUT;
     p2->keywords = p->keywords;
     p2->n_keyword_lists = p->n_keyword_lists;
     p2->tokens = PyMem_Malloc(sizeof(Token *));

--- a/pegen/parse_string.c
+++ b/pegen/parse_string.c
@@ -570,9 +570,12 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     PyErr_Clear();
     mod = the_start_rule(p2);
 
-    PyTokenizer_Free(tok);
-
     if (mod == NULL){
+        p2->tok->filename = PyUnicode_FromString("<string>");
+        if (p2->tok->filename == NULL) {
+            goto exit;
+        }
+        raise_syntax_error(p2, "invalid syntax");
         goto exit;
     }
 
@@ -593,6 +596,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     fstring_fix_expr_location(t, expr->v.Expr.value, str);
 
 exit:
+    PyTokenizer_Free(tok);
     for (int i = 0; i < p2->size; i++) {
         PyMem_Free(p2->tokens[i]);
     }

--- a/pegen/parse_string.c
+++ b/pegen/parse_string.c
@@ -542,6 +542,11 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     if (tok == NULL) {
         return NULL;
     }
+    tok->filename = PyUnicode_FromString("<fstring>");
+    if (!tok->filename) {
+        PyTokenizer_Free(tok);
+        return NULL;
+    }
     mod_ty (*the_start_rule)(Parser*) = p->start_rule_func;
 
     Parser *p2 = PyMem_Malloc(sizeof(Parser));
@@ -550,6 +555,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
         goto exit;
     }
     p2->tok = tok;
+    p2->input_mode = 2;
     p2->keywords = p->keywords;
     p2->n_keyword_lists = p->n_keyword_lists;
     p2->tokens = PyMem_Malloc(sizeof(Token *));
@@ -571,10 +577,6 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     mod = the_start_rule(p2);
 
     if (mod == NULL){
-        p2->tok->filename = PyUnicode_FromString("<string>");
-        if (p2->tok->filename == NULL) {
-            goto exit;
-        }
         raise_syntax_error(p2, "invalid syntax");
         goto exit;
     }

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -36,6 +36,17 @@ byte_offset_to_character_offset(PyObject *line, int col_offset)
     return size;
 }
 
+static void
+get_error_line(PyObject **loc, char *buffer)
+{
+    char *newline = strchr(buffer, '\n');
+    if (newline) {
+        *loc = PyUnicode_FromStringAndSize(buffer, newline - buffer);
+    } else {
+        *loc = PyUnicode_FromString(buffer);
+    }
+}
+
 int
 raise_syntax_error(Parser *p, const char *errmsg, ...)
 {
@@ -62,7 +73,7 @@ raise_syntax_error(Parser *p, const char *errmsg, ...)
             loc = Py_None;
         }
     } else {
-        loc = PyUnicode_FromString(p->tok->buf);
+        get_error_line(&loc, p->tok->buf);
         if (!loc) {
             goto error;
         }

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -63,7 +63,7 @@ raise_syntax_error(Parser *p, const char *errmsg, ...)
     if (!errstr) {
         goto error;
     }
-    if (p->input_mode == 0) {
+    if (p->input_mode == FILE_INPUT) {
         if (PyErr_Occurred()){
             goto error;
         }
@@ -613,7 +613,7 @@ run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), in
     tok->filename = filename_ob;
     filename_ob = NULL;
 
-    result = run_parser(tok, start_rule_func, mode, 0, keywords, n_keyword_lists);
+    result = run_parser(tok, start_rule_func, mode, FILE_INPUT, keywords, n_keyword_lists);
 
     PyTokenizer_Free(tok);
 
@@ -636,7 +636,7 @@ run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int m
     if (tok->filename == NULL) {
         goto exit;
     }
-    result = run_parser(tok, start_rule_func, mode, 1, keywords, n_keyword_lists);
+    result = run_parser(tok, start_rule_func, mode, STRING_INPUT, keywords, n_keyword_lists);
 exit:
     PyTokenizer_Free(tok);
     return result;

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -10,7 +10,6 @@
 enum INPUT_MODE {
     FILE_INPUT,
     STRING_INPUT,
-    FSTRING_INPUT
 };
 typedef enum INPUT_MODE INPUT_MODE;
 

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -7,6 +7,12 @@
 #include <Python-ast.h>
 #include <pyarena.h>
 
+enum INPUT_MODE {
+    FILE_INPUT,
+    STRING_INPUT,
+    FSTRING_INPUT
+};
+
 typedef struct _memo {
     int type;
     void *node;
@@ -25,6 +31,7 @@ typedef struct {
     char *str;
     int type;
 } KeywordToken;
+
 
 typedef struct {
     struct tok_state *tok;

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -12,6 +12,7 @@ enum INPUT_MODE {
     STRING_INPUT,
     FSTRING_INPUT
 };
+typedef enum INPUT_MODE INPUT_MODE;
 
 typedef struct _memo {
     int type;
@@ -42,7 +43,7 @@ typedef struct {
     KeywordToken **keywords;
     int n_keyword_lists;
     void *start_rule_func;
-    int input_mode;  // Where the input comes from (0 for file, 1 for string, 2 for fstring)
+    INPUT_MODE input_mode;  // Where the input comes from (0 for file, 1 for string, 2 for fstring)
 } Parser;
 
 typedef struct {

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -35,6 +35,7 @@ typedef struct {
     KeywordToken **keywords;
     int n_keyword_lists;
     void *start_rule_func;
+    int input_mode;  // Where the input comes from (0 for file, 1 for string, 2 for fstring)
 } Parser;
 
 typedef struct {

--- a/test/test_tracebacks.py
+++ b/test/test_tracebacks.py
@@ -8,7 +8,7 @@ import pytest  # type: ignore
 from pegen.grammar_parser import GeneratedParser as GrammarParser
 from pegen.testutil import parse_string, generate_parser_c_extension
 
-#  fmt: off
+# fmt: off
 
 FSTRINGS: Dict[str, Tuple[str, str]] = {
     'multiline_fstrings_same_line_with_brace': (
@@ -37,7 +37,7 @@ FSTRINGS: Dict[str, Tuple[str, str]] = {
     ),
 }
 
-#  fmt: on
+# fmt: on
 
 
 def create_tmp_extension(tmp_path: PurePath) -> Any:
@@ -54,8 +54,11 @@ def parser_extension(tmp_path_factory: Any) -> Any:
     extension = create_tmp_extension(tmp_path)
     return extension
 
+
 @pytest.mark.parametrize("fstring,error_line", FSTRINGS.values(), ids=tuple(FSTRINGS.keys()))
-def test_fstring_syntax_error_tracebacks(parser_extension: Any, fstring: str, error_line: str) -> None:
+def test_fstring_syntax_error_tracebacks(
+    parser_extension: Any, fstring: str, error_line: str
+) -> None:
     try:
         parser_extension.parse_string(dedent(fstring))
     except SyntaxError as se:

--- a/test/test_tracebacks.py
+++ b/test/test_tracebacks.py
@@ -1,0 +1,62 @@
+import os
+from pathlib import PurePath
+from typing import Any, Dict, Tuple
+from textwrap import dedent
+
+import pytest
+
+from pegen.grammar_parser import GeneratedParser as GrammarParser
+from pegen.testutil import parse_string, generate_parser_c_extension
+
+#  fmt: off
+
+FSTRINGS: Dict[str, Tuple[str, str]] = {
+    'multiline_fstrings_same_line_with_brace': (
+        """
+            f'''
+            {a$b}
+            '''
+        """,
+        '(a$b)',
+    ),
+    'multiline_fstring_brace_on_next_line': (
+        """
+            f'''
+            {a$b
+            }'''
+        """,
+        '(a$b',
+    ),
+    'multiline_fstring_brace_on_previous_line': (
+        """
+            f'''
+            {
+            a$b}'''
+        """,
+        'a$b)',
+    ),
+}
+
+#  fmt: on
+
+
+def create_tmp_extension(tmp_path: PurePath) -> Any:
+    with open(os.path.join("data", "simpy.gram"), "r") as grammar_file:
+        grammar_source = grammar_file.read()
+    grammar = parse_string(grammar_source, GrammarParser)
+    extension = generate_parser_c_extension(grammar, tmp_path)
+    return extension
+
+
+@pytest.fixture(scope="module")
+def parser_extension(tmp_path_factory: Any) -> Any:
+    tmp_path = tmp_path_factory.mktemp("extension")
+    extension = create_tmp_extension(tmp_path)
+    return extension
+
+@pytest.mark.parametrize("fstring,error_line", FSTRINGS.values(), ids=tuple(FSTRINGS.keys()))
+def test_fstring_syntax_error_tracebacks(parser_extension: Any, fstring: str, error_line: str) -> None:
+    try:
+        parser_extension.parse_string(dedent(fstring))
+    except SyntaxError as se:
+        assert se.text == error_line

--- a/test/test_tracebacks.py
+++ b/test/test_tracebacks.py
@@ -3,7 +3,7 @@ from pathlib import PurePath
 from typing import Any, Dict, Tuple
 from textwrap import dedent
 
-import pytest
+import pytest  # type: ignore
 
 from pegen.grammar_parser import GeneratedParser as GrammarParser
 from pegen.testutil import parse_string, generate_parser_c_extension


### PR DESCRIPTION
With this PR:

```
venv ❯ python -c 'from pegen import parse; parse.parse_string("f\"{x$4+34+34}\"")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1
    (x$4+34+34)
      ^
SyntaxError: invalid syntax
```