### PR TITLE
Reject invalid expressions in the for-if clauses of a comprehension

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -388,7 +388,7 @@ kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { key_value_pair(p, NULL, a) }
     | a=expression ':' b=expression { key_value_pair(p, a, b) }
 for_if_clauses[asdl_seq*]:
-    | a=(y=[ASYNC] 'for' a=star_targets 'in' b=expression c=('if' z=expression { z })*
+    | a=(y=[ASYNC] 'for' a=star_targets 'in' b=disjunction c=('if' z=disjunction { z })*
         { _Py_comprehension(a, b, c, (y == NULL) ? 0 : 1, p->arena) })+ { a }
 
 yield_expr[expr_ty]:

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -512,6 +512,8 @@ FAIL_TEST_CASES = [
     ("annotation_tuple", "(a,): int"),
     ("annotation_tuple_without_paren", "a,: int"),
     ("assignment_keyword", "a = if"),
+    ("comprehension_lambda", "(a for a in lambda: b)"),
+    ("comprehension_else", "(a for a in b if c else d"),
     ("del_call", "del a()"),
     ("del_call_genexp", "del a(i for i in b)"),
     ("del_subscript_call", "del a[b]()"),


### PR DESCRIPTION
For example, pegen currently accepts the invalid `(a for a in lambda: b)`.

I found this out, while investigating the Travis failures in #213. This also stresses the need for testing with invalid input.