### PR TITLE
Remove lookaheads that are not needed anymore

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -74,7 +74,7 @@ import_stmt[stmt_ty]: import_name | import_from
 import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from[stmt_ty]:
-    | 'from' a=('.' | '...')* !'import' b=dotted_name 'import' c=import_from_targets {
+    | 'from' a=('.' | '...')* b=dotted_name 'import' c=import_from_targets {
         _Py_ImportFrom(b->v.Name.id, c, seq_count_dots(a), EXTRA) }
     | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
         _Py_ImportFrom(NULL, b, seq_count_dots(a), EXTRA) }
@@ -422,12 +422,11 @@ kwarg[KeywordOrStarred*]:
     | '**' a=expression { keyword_or_starred(p, _Py_keyword(NULL, a, p->arena), 1) }
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
-# NOTE: the !'in' is to handle "for x, in ...".
 star_targets[expr_ty]:
     | a=star_target !',' { a }
-    | a=star_target b=(',' !'in' c=star_target { c })* [','] {
+    | a=star_target b=(',' c=star_target { c })* [','] {
         _Py_Tuple(seq_insert_in_front(p, a, b), Store, EXTRA) }
-star_targets_seq[asdl_seq*]: a=star_target b=(',' !'in' c=star_target { c })* [','] {
+star_targets_seq[asdl_seq*]: a=star_target b=(',' c=star_target { c })* [','] {
     seq_insert_in_front(p, a, b) }
 star_target[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(set_expr_context(p, a, Store), Store, EXTRA) }

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -523,12 +523,14 @@ FAIL_TEST_CASES = [
     ("for_star_targets_subscript_call", "for a[b]() in c: pass"),
     ("for_star_targets_attribute_call", "for a.b() in c: pass"),
     ("for_star_targets_mixed_call", "for a[0].b().c.d() in e: pass"),
+    ("for_star_targets_in", "for a, in in b: pass"),
     ("f-string_assignment", "f'{x = 42}'"),
     ("f-string_empty", "f'{}'"),
     ("f-string_function_def", "f'{def f(): pass}'"),
     ("f-string_lambda", "f'{lambda x: 42}'"),
     ("f-string_singe_brace", "f'{'"),
     ("f-string_single_closing_brace", "f'}'"),
+    ("from_import_invalid", "from import import a"),
     # This test case checks error paths involving tokens with uninitialized
     # values of col_offset and end_col_offset.
     ("invalid indentation",


### PR DESCRIPTION
Now that we handle keywords correctly, we can remove these.