### PR TITLE
Make the empty tuple a valid target

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -435,7 +435,7 @@ star_target[expr_ty]:
     | star_atom
 star_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
-    | '(' a=[star_target] ')' { set_expr_context(p, a, Store) }
+    | '(' a=star_target ')' { set_expr_context(p, a, Store) }
     | '(' a=[star_targets_seq] ')' { _Py_Tuple(a, Store, EXTRA) }
     | '[' a=[star_targets_seq] ']' { _Py_List(a, Store, EXTRA) }
 
@@ -455,7 +455,7 @@ del_target[expr_ty]:
     | del_t_atom
 del_t_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Del) }
-    | '(' a=[del_target] ')' { set_expr_context(p, a, Del) }
+    | '(' a=del_target ')' { set_expr_context(p, a, Del) }
     | '(' a=[del_targets] ')' { _Py_Tuple(a, Del, EXTRA) }
     | '[' a=[del_targets] ']' { _Py_List(a, Del, EXTRA) }
 
@@ -477,6 +477,6 @@ t_primary[expr_ty]:
 t_lookahead: '(' | '[' | '.'
 t_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
-    | '(' a=[target] ')' { set_expr_context(p, a, Store) }
+    | '(' a=target ')' { set_expr_context(p, a, Store) }
     | '(' b=[targets] ')' { _Py_Tuple(b, Store, EXTRA) }
     | '[' b=[targets] ']' { _Py_List(b, Store, EXTRA) }

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -108,6 +108,7 @@ TEST_CASES = [
     ('del_attribute', 'del a.b'),
     ('del_call_attribute', 'del a().c'),
     ('del_call_genexp_attribute', 'del a(i for i in b).c'),
+    ('del_empty', 'del()'),
     ('del_list', 'del a, [b, c]'),
     ('del_mixed', 'del a[0].b().c'),
     ('del_multiple', 'del a, b'),
@@ -142,6 +143,7 @@ TEST_CASES = [
     ('for_star_target_in_paren', 'for (a) in b: pass'),
     ('for_star_targets_attribute', 'for a.b in c: pass'),
     ('for_star_targets_call_attribute', 'for a().c in b: pass'),
+    ('for_star_targets_empty', 'for () in a: pass'),
     ('for_star_targets_mixed', 'for a[0].b().c in d: pass'),
     ('for_star_targets_mixed_starred',
      '''
@@ -506,6 +508,7 @@ TEST_CASES = [
         with a as (b):
             pass
      '''),
+    ('with_as_empty', 'with a as (): pass'),
     ('with_list_recursive',
      '''
         with a as [x, [y, z]]:


### PR DESCRIPTION
While investigating the `simpy_cpython` failure on #130, I found out that statements with the empty tuple as target such as `del()`, `for () in a: pass` and `with a as (): pass` get rejected.  