### PR TITLE
Add memoization control (for now, C only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ stats: peg_parser/parse.c
 time: time_compile
 
 time_compile: peg_parser/parse.c
-	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=2); parse.dump()"
+	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=2); parse.dump()" >@data
 
 time_parse: peg_parser/parse.c
 	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=1)"

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,13 @@ parse: peg_parser/parse.c
 check: peg_parser/parse.c
 	$(PYTHON) -c "from peg_parser import parse; t = parse.parse_file('$(TESTFILE)', mode=0)"
 
+stats: peg_parser/parse.c
+	$(PYTHON) -c "from peg_parser import parse; t = parse.parse_file('$(TIMEFILE)', mode=0); parse.dump()"
+
 time: time_compile
 
 time_compile: peg_parser/parse.c
-	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=2)"
+	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=2); parse.dump()"
 
 time_parse: peg_parser/parse.c
 	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=1)"

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,13 @@ check: peg_parser/parse.c
 	$(PYTHON) -c "from peg_parser import parse; t = parse.parse_file('$(TESTFILE)', mode=0)"
 
 stats: peg_parser/parse.c
-	$(PYTHON) -c "from peg_parser import parse; t = parse.parse_file('$(TIMEFILE)', mode=0); parse.dump()"
+	$(PYTHON) -c "from peg_parser import parse; t = parse.parse_file('$(TIMEFILE)', mode=0); parse.dump_memo_stats()" >@data
+	$(PYTHON) scripts/joinstats.py @data
 
 time: time_compile
 
 time_compile: peg_parser/parse.c
-	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=2); parse.dump()" >@data
+	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=2)"
 
 time_parse: peg_parser/parse.c
 	/usr/bin/time -l $(PYTHON) -c "from peg_parser import parse; parse.parse_file('$(TIMEFILE)', mode=1)"

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -1,15 +1,15 @@
 # Simplified grammar for Python
 
-~start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
 statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
 
-~statement[asdl_seq*]: a=compound_stmt { singleton_seq(p, a) } | simple_stmt
-~simple_stmt[asdl_seq*]:
+statement[asdl_seq*]: a=compound_stmt { singleton_seq(p, a) } | simple_stmt
+simple_stmt[asdl_seq*]:
     | a=small_stmt !';' NEWLINE { singleton_seq(p, a) } # Not needed, there for speedup
     | a=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
-~small_stmt[stmt_ty]:
+small_stmt[stmt_ty]:
     | assignment
     | e=expressions { _Py_Expr(e, EXTRA) }
     | &'return' return_stmt
@@ -23,7 +23,7 @@ statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
     | 'continue' { _Py_Continue(EXTRA) }
     | &'global' global_stmt
     | &'nonlocal' nonlocal_stmt
-~compound_stmt[stmt_ty]:
+compound_stmt[stmt_ty]:
     | &('def' | '@' | ASYNC) function_def
     | &'if' if_stmt
     | &('class' | '@') class_def
@@ -32,7 +32,7 @@ statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
     | &'try' try_stmt
     | &'while' while_stmt
 
-~assignment:
+assignment:
     | a=NAME ':' b=expression c=['=' d=annotated_rhs { d }] {
         _Py_AnnAssign(CHECK(set_expr_context(p, a, Store)), b, c, 1, EXTRA) }
     | a=('(' b=inside_paren_ann_assign_target ')' { b }
@@ -43,7 +43,7 @@ statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
     | a=target b=augassign c=(yield_expr | expressions) {
          _Py_AugAssign(a, b->kind, c, EXTRA) }
 
-~augassign[AugOperator*]:
+augassign[AugOperator*]:
     | '+=' {augoperator(p, Add)}
     | '-=' {augoperator(p, Sub)}
     | '*=' {augoperator(p, Mult)}
@@ -58,36 +58,36 @@ statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
     | '**=' {augoperator(p, Pow)}
     | '//=' {augoperator(p, FloorDiv)}
 
-~global_stmt[stmt_ty]: 'global' a=','.NAME+ { _Py_Global(CHECK(map_names_to_ids(p, a)), EXTRA) }
-~nonlocal_stmt[stmt_ty]: 'nonlocal' a=','.NAME+ { _Py_Nonlocal(CHECK(map_names_to_ids(p, a)), EXTRA) }
+global_stmt[stmt_ty]: 'global' a=','.NAME+ { _Py_Global(CHECK(map_names_to_ids(p, a)), EXTRA) }
+nonlocal_stmt[stmt_ty]: 'nonlocal' a=','.NAME+ { _Py_Nonlocal(CHECK(map_names_to_ids(p, a)), EXTRA) }
 
-~yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
+yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
 
-~assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
+assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
 
-~del_stmt[stmt_ty]: 'del' a=del_targets { _Py_Delete(a, EXTRA) }
+del_stmt[stmt_ty]: 'del' a=del_targets { _Py_Delete(a, EXTRA) }
 
-~import_stmt[stmt_ty]: import_name | import_from
-~import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
+import_stmt[stmt_ty]: import_name | import_from
+import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
-~import_from[stmt_ty]:
+import_from[stmt_ty]:
     | 'from' a=('.' | '...')* b=dotted_name 'import' c=import_from_targets {
         _Py_ImportFrom(b->v.Name.id, c, seq_count_dots(a), EXTRA) }
     | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
         _Py_ImportFrom(NULL, b, seq_count_dots(a), EXTRA) }
-~import_from_targets[asdl_seq*]:
+import_from_targets[asdl_seq*]:
     | '(' a=import_from_as_names ')' { a }
     | import_from_as_names
     | '*' { singleton_seq(p, CHECK(alias_for_star(p))) }
-~import_from_as_names[asdl_seq*]:
+import_from_as_names[asdl_seq*]:
     | a=','.import_from_as_name+ [','] { a }
-~import_from_as_name[alias_ty]:
+import_from_as_name[alias_ty]:
     | a=NAME b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                p->arena) }
-~dotted_as_names[asdl_seq*]:
+dotted_as_names[asdl_seq*]:
     | a=','.dotted_as_name+ { a }
-~dotted_as_name[alias_ty]:
+dotted_as_name[alias_ty]:
     | a=dotted_name b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                       (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                       p->arena) }
@@ -95,24 +95,24 @@ dotted_name[expr_ty]:
     | a=dotted_name '.' b=NAME { join_names_with_dot(p, a, b) }
     | NAME
 
-~if_stmt[stmt_ty]:
+if_stmt[stmt_ty]:
     | 'if' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK(singleton_seq(p, c)), EXTRA) }
     | 'if' a=named_expression ':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
-~elif_stmt[stmt_ty]:
+elif_stmt[stmt_ty]:
     | 'elif' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK(singleton_seq(p, c)), EXTRA) }
     | 'elif' a=named_expression ':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
-~else_block[asdl_seq*]: 'else' ':' b=block { b }
+else_block[asdl_seq*]: 'else' ':' b=block { b }
 
-~while_stmt[stmt_ty]:
+while_stmt[stmt_ty]:
     | 'while' a=named_expression ':' b=block c=[else_block] { _Py_While(a, b, c, EXTRA) }
 
-~for_stmt[stmt_ty]:
+for_stmt[stmt_ty]:
     | ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block el=[else_block] {
         _Py_AsyncFor(t, ex, b, el, NULL, EXTRA) }
     | 'for' t=star_targets 'in' ex=expressions ':' b=block el=[else_block] {
         _Py_For(t, ex, b, el, NULL, EXTRA) }
 
-~with_stmt[stmt_ty]:
+with_stmt[stmt_ty]:
     | ASYNC 'with' '(' a=','.with_item+ ')' ':' b=block {
         _Py_AsyncWith(a, b, NULL, EXTRA) }
     | ASYNC 'with' a=','.with_item+ ':' b=block {
@@ -121,30 +121,30 @@ dotted_name[expr_ty]:
         _Py_With(a, b, NULL, EXTRA) }
     | 'with' a=','.with_item+ ':' b=block {
         _Py_With(a, b, NULL, EXTRA) }
-~with_item[withitem_ty]:
+with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, o, p->arena) }
 
-~try_stmt[stmt_ty]:
+try_stmt[stmt_ty]:
     | 'try' ':' b=block f=finally_block { _Py_Try(b, NULL, NULL, f, EXTRA) }
     | 'try' ':' b=block ex=except_block+ el=[else_block] f=[finally_block] { _Py_Try(b, ex, el, f, EXTRA) }
-~except_block[excepthandler_ty]:
+except_block[excepthandler_ty]:
     | 'except' e=expression t=['as' z=target { z }] ':' b=block {
         _Py_ExceptHandler(e, (t) ? ((expr_ty) t)->v.Name.id : NULL, b, EXTRA) }
     | 'except' ':' b=block { _Py_ExceptHandler(NULL, NULL, b, EXTRA) }
-~finally_block[asdl_seq*]: 'finally' ':' a=block { a }
+finally_block[asdl_seq*]: 'finally' ':' a=block { a }
 
-~return_stmt[stmt_ty]:
+return_stmt[stmt_ty]:
     | 'return' a=[expressions] { _Py_Return(a, EXTRA) }
 
-~raise_stmt[stmt_ty]:
+raise_stmt[stmt_ty]:
     | 'raise' a=expression b=['from' z=expression { z }] { _Py_Raise(a, b, EXTRA) }
     | 'raise' { _Py_Raise(NULL, NULL, EXTRA) }
 
-~function_def[stmt_ty]:
+function_def[stmt_ty]:
     | d=decorators f=function_def_raw { function_def_decorators(p, d, f) }
     | function_def_raw
 
-~function_def_raw[stmt_ty]:
+function_def_raw[stmt_ty]:
     | ASYNC 'def' n=NAME '(' params=[parameters] ')' a=['->' z=annotation { z }] ':' b=block {
         _Py_AsyncFunctionDef(n->v.Name.id,
                              (params) ? params : CHECK(empty_arguments(p)),
@@ -154,7 +154,7 @@ dotted_name[expr_ty]:
                         (params) ? params : CHECK(empty_arguments(p)),
                         b, NULL, a, NULL, EXTRA) }
 
-~parameters[arguments_ty]:
+parameters[arguments_ty]:
     | a=slash_without_default b=[',' x=plain_names { x }] c=[',' y=names_with_default { y }] d=[',' z=[star_etc] { z }] {
         make_arguments(p, a, NULL, b, c, d) }
     | a=slash_with_default b=[',' y=names_with_default { y }] c=[',' z=[star_etc] { z }] {
@@ -163,67 +163,67 @@ dotted_name[expr_ty]:
         make_arguments(p, NULL, NULL, a, b, c) }
     | a=names_with_default b=[',' z=[star_etc] { z }] { make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=star_etc { make_arguments(p, NULL, NULL, NULL, NULL, a) }
-~slash_without_default[asdl_seq*]: a=plain_names ',' '/' { a }
-~slash_with_default[SlashWithDefault*]: a=[n=plain_names ',' { n }] b=names_with_default ',' '/' {
+slash_without_default[asdl_seq*]: a=plain_names ',' '/' { a }
+slash_with_default[SlashWithDefault*]: a=[n=plain_names ',' { n }] b=names_with_default ',' '/' {
     slash_with_default(p, a, b) }
-~star_etc[StarEtc*]:
+star_etc[StarEtc*]:
     | '*' a=plain_name b=name_with_optional_default* c=[',' d=kwds { d }] [','] {
         star_etc(p, a, b, c) }
     | '*' b=name_with_optional_default+ c=[',' d=kwds { d }] [','] {
         star_etc(p, NULL, b, c) }
     | a=kwds [','] { star_etc(p, NULL, NULL, a) }
-~name_with_optional_default[NameDefaultPair*]:
+name_with_optional_default[NameDefaultPair*]:
     | ',' a=plain_name b=['=' e=expression { e }] { name_default_pair(p, a, b) }
-~names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
-~name_with_default[NameDefaultPair*]:
+names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
+name_with_default[NameDefaultPair*]:
     | n=plain_name '=' e=expression { name_default_pair(p, n, e) }
-~plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
-~plain_name[arg_ty]:
+plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
+plain_name[arg_ty]:
     | a=NAME b=[':' z=annotation { z }] { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
-~kwds[arg_ty]:
+kwds[arg_ty]:
     | '**' a=plain_name { a }
-~annotation[expr_ty]: expression
+annotation[expr_ty]: expression
 
-~decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
+decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
 
-~class_def[stmt_ty]:
+class_def[stmt_ty]:
     | a=decorators b=class_def_raw { class_def_decorators(p, a, b) }
     | class_def_raw
-~class_def_raw[stmt_ty]:
+class_def_raw[stmt_ty]:
     | 'class' a=NAME b=['(' z=[arguments] ')' { z }] ':' c=block {
         _Py_ClassDef(a->v.Name.id,
                      (b) ? ((expr_ty) b)->v.Call.args : NULL,
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
 
-~block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
+block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
 
-~expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
-~expressions[expr_ty]:
+expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
+expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
         _Py_Tuple(CHECK(seq_insert_in_front(p, a, b)), Load, EXTRA) }
     | a=star_expression ',' { _Py_Tuple(CHECK(singleton_seq(p, a)), Load, EXTRA) }
     | star_expression
-~star_expression[expr_ty]:
+star_expression[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | expression
 
-~star_named_expressions[asdl_seq*]: a=','.star_named_expression+ [','] { a }
-~star_named_expression[expr_ty]:
+star_named_expressions[asdl_seq*]: a=','.star_named_expression+ [','] { a }
+star_named_expression[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | named_expression
-~named_expression[expr_ty]:
+named_expression[expr_ty]:
     | a=NAME ':=' b=expression { _Py_NamedExpr(CHECK(set_expr_context(p, a, Store)), b, EXTRA) }
     | expression
-~annotated_rhs[expr_ty]: yield_expr | expressions
-~expression[expr_ty]:
+annotated_rhs[expr_ty]: yield_expr | expressions
+expression[expr_ty]:
     | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
 
-~lambdef[expr_ty]:
+lambdef[expr_ty]:
     | 'lambda' a=[lambda_parameters] ':' b=expression { _Py_Lambda((a) ? a : CHECK(empty_arguments(p)), b, EXTRA) }
-~lambda_parameters[arguments_ty]:
+lambda_parameters[arguments_ty]:
     | a=lambda_slash_without_default b=[',' x=lambda_plain_names { x }] c=[',' y=lambda_names_with_default { y }] d=[',' z=[lambda_star_etc] { z }] {
         make_arguments(p, a, NULL, b, c, d) }
     | a=lambda_slash_with_default b=[',' y=lambda_names_with_default { y }] c=[',' z=[lambda_star_etc] { z }] {
@@ -232,44 +232,44 @@ dotted_name[expr_ty]:
         make_arguments(p, NULL, NULL, a, b, c) }
     | a=lambda_names_with_default b=[',' z=[lambda_star_etc] { z }] { make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=lambda_star_etc { make_arguments(p, NULL, NULL, NULL, NULL, a) }
-~lambda_slash_without_default[asdl_seq*]: a=lambda_plain_names ',' '/' { a }
-~lambda_slash_with_default[SlashWithDefault*]: a=[n=lambda_plain_names ',' { n }] b=lambda_names_with_default ',' '/' {
+lambda_slash_without_default[asdl_seq*]: a=lambda_plain_names ',' '/' { a }
+lambda_slash_with_default[SlashWithDefault*]: a=[n=lambda_plain_names ',' { n }] b=lambda_names_with_default ',' '/' {
     slash_with_default(p, a, b) }
-~lambda_star_etc[StarEtc*]:
+lambda_star_etc[StarEtc*]:
     | '*' a=lambda_plain_name b=lambda_name_with_optional_default* c=[',' d=lambda_kwds { d }] [','] {
         star_etc(p, a, b, c) }
     | '*' b=lambda_name_with_optional_default+ c=[',' d=lambda_kwds { d }] [','] {
         star_etc(p, NULL, b, c) }
     | a=lambda_kwds [','] { star_etc(p, NULL, NULL, a) }
-~lambda_name_with_optional_default[NameDefaultPair*]:
+lambda_name_with_optional_default[NameDefaultPair*]:
     | ',' a=lambda_plain_name b=['=' e=expression { e }] { name_default_pair(p, a, b) }
-~lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
-~lambda_name_with_default[NameDefaultPair*]:
+lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
+lambda_name_with_default[NameDefaultPair*]:
     | n=lambda_plain_name '=' e=expression { name_default_pair(p, n, e) }
-~lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
-~lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
-~lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
+lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
+lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
+lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
 
-~disjunction[expr_ty]:
+disjunction[expr_ty]:
     | a=conjunction b=('or' c=conjunction { c })+ { _Py_BoolOp(
         Or,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | conjunction
-~conjunction[expr_ty]:
+conjunction[expr_ty]:
     | a=inversion b=('and' c=inversion { c })+ { _Py_BoolOp(
         And,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | inversion
-~inversion[expr_ty]:
+inversion[expr_ty]:
     | 'not' a=inversion { _Py_UnaryOp(Not, a, EXTRA) }
     | comparison
-~comparison[expr_ty]:
+comparison[expr_ty]:
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
         _Py_Compare(a, CHECK(get_cmpops(p, b)), CHECK(get_exprs(p, b)), EXTRA) }
     | bitwise_or
-~compare_op_bitwise_or_pair[CmpopExprPair*]:
+compare_op_bitwise_or_pair[CmpopExprPair*]:
     | eq_bitwise_or
     | noteq_bitwise_or
     | lte_bitwise_or
@@ -280,54 +280,54 @@ dotted_name[expr_ty]:
     | in_bitwise_or
     | isnot_bitwise_or
     | is_bitwise_or
-~eq_bitwise_or[CmpopExprPair*]: '==' a=bitwise_or { cmpop_expr_pair(p, Eq, a) }
-~noteq_bitwise_or[CmpopExprPair*]: '!=' a=bitwise_or { cmpop_expr_pair(p, NotEq, a) }
-~lte_bitwise_or[CmpopExprPair*]: '<=' a=bitwise_or { cmpop_expr_pair(p, LtE, a) }
-~lt_bitwise_or[CmpopExprPair*]: '<' a=bitwise_or { cmpop_expr_pair(p, Lt, a) }
-~gte_bitwise_or[CmpopExprPair*]: '>=' a=bitwise_or { cmpop_expr_pair(p, GtE, a) }
-~gt_bitwise_or[CmpopExprPair*]: '>' a=bitwise_or { cmpop_expr_pair(p, Gt, a) }
-~notin_bitwise_or[CmpopExprPair*]: 'not' 'in' a=bitwise_or { cmpop_expr_pair(p, NotIn, a) }
-~in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { cmpop_expr_pair(p, In, a) }
-~isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { cmpop_expr_pair(p, IsNot, a) }
-~is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { cmpop_expr_pair(p, Is, a) }
+eq_bitwise_or[CmpopExprPair*]: '==' a=bitwise_or { cmpop_expr_pair(p, Eq, a) }
+noteq_bitwise_or[CmpopExprPair*]: '!=' a=bitwise_or { cmpop_expr_pair(p, NotEq, a) }
+lte_bitwise_or[CmpopExprPair*]: '<=' a=bitwise_or { cmpop_expr_pair(p, LtE, a) }
+lt_bitwise_or[CmpopExprPair*]: '<' a=bitwise_or { cmpop_expr_pair(p, Lt, a) }
+gte_bitwise_or[CmpopExprPair*]: '>=' a=bitwise_or { cmpop_expr_pair(p, GtE, a) }
+gt_bitwise_or[CmpopExprPair*]: '>' a=bitwise_or { cmpop_expr_pair(p, Gt, a) }
+notin_bitwise_or[CmpopExprPair*]: 'not' 'in' a=bitwise_or { cmpop_expr_pair(p, NotIn, a) }
+in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { cmpop_expr_pair(p, In, a) }
+isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { cmpop_expr_pair(p, IsNot, a) }
+is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { cmpop_expr_pair(p, Is, a) }
 
-~bitwise_or[expr_ty]:
+bitwise_or[expr_ty]:
     | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA) }
     | bitwise_xor
-~bitwise_xor[expr_ty]:
+bitwise_xor[expr_ty]:
     | a=bitwise_xor '^' b=bitwise_and { _Py_BinOp(a, BitXor, b, EXTRA) }
     | bitwise_and
-~bitwise_and[expr_ty]:
+bitwise_and[expr_ty]:
     | a=bitwise_and '&' b=shift_expr { _Py_BinOp(a, BitAnd, b, EXTRA) }
     | shift_expr
-~shift_expr[expr_ty]:
+shift_expr[expr_ty]:
     | a=shift_expr '<<' b=sum { _Py_BinOp(a, LShift, b, EXTRA) }
     | a=shift_expr '>>' b=sum { _Py_BinOp(a, RShift, b, EXTRA) }
     | sum
 
-~sum[expr_ty]:
+sum[expr_ty]:
     | a=sum '+' b=term { _Py_BinOp(a, Add, b, EXTRA) }
     | a=sum '-' b=term { _Py_BinOp(a, Sub, b, EXTRA) }
     | term
-~term[expr_ty]:
+term[expr_ty]:
     | a=term '*' b=factor { _Py_BinOp(a, Mult, b, EXTRA) }
     | a=term '/' b=factor { _Py_BinOp(a, Div, b, EXTRA) }
     | a=term '//' b=factor { _Py_BinOp(a, FloorDiv, b, EXTRA) }
     | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
     | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA) }
     | factor
-~factor[expr_ty]:
+factor[expr_ty]:
     | '+' a=factor { _Py_UnaryOp(UAdd, a, EXTRA) }
     | '-' a=factor { _Py_UnaryOp(USub, a, EXTRA) }
     | '~' a=factor { _Py_UnaryOp(Invert, a, EXTRA) }
     | power
-~power[expr_ty]:
+power[expr_ty]:
     | a=await_primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
     | await_primary
-~await_primary[expr_ty]:
+await_primary[expr_ty]:
     | AWAIT a=primary { _Py_Await(a, EXTRA) }
     | primary
-~primary[expr_ty]:
+primary[expr_ty]:
     | a=primary '.' b=NAME { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
     | a=primary b=genexp { _Py_Call(a, CHECK(singleton_seq(p, b)), NULL, EXTRA) }
     | a=primary '(' b=[arguments] ')' {
@@ -338,19 +338,19 @@ dotted_name[expr_ty]:
     | a=primary b=slicing { _Py_Subscript(a, b, Load, EXTRA) }
     | atom
 
-~slicing[slice_ty]:
+slicing[slice_ty]:
     | '[' b=expression ']' { _Py_Index(b, p->arena) }
     | '[' b=slice_expressions ']' { b }
     | '[' b=slices ']' { b }
-~slice_expressions[slice_ty]:
+slice_expressions[slice_ty]:
     | a=','.expression+ [','] { _Py_Index(_Py_Tuple(a, Load, EXTRA), p->arena) }
-~slices[slice_ty]:
+slices[slice_ty]:
     | a=slice !',' { a }
     | a=','.slice+ [','] { _Py_ExtSlice(a, p->arena) }
-~slice[slice_ty]:
+slice[slice_ty]:
     | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, p->arena) }
     | a=expression { _Py_Index(a, p->arena) }
-~atom[expr_ty]:
+atom[expr_ty]:
     | NAME
     | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
     | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
@@ -362,39 +362,39 @@ dotted_name[expr_ty]:
     | &'{' (dict | set | dictcomp | setcomp)
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
-~list[expr_ty]:
+list[expr_ty]:
     | '[' a=[star_named_expressions] ']' { _Py_List(a, Load, EXTRA) }
-~listcomp[expr_ty]:
+listcomp[expr_ty]:
     | '[' a=named_expression b=for_if_clauses ']' { _Py_ListComp(a, b, EXTRA) }
-~tuple[expr_ty]:
+tuple[expr_ty]:
     | '(' a=[y=star_named_expression ',' z=[star_named_expressions] { seq_insert_in_front(p, y, z) } ] ')' {
         _Py_Tuple(a, Load, EXTRA) }
-~group[expr_ty]: '(' a=(yield_expr | named_expression) ')' { a }
-~genexp[expr_ty]:
+group[expr_ty]: '(' a=(yield_expr | named_expression) ')' { a }
+genexp[expr_ty]:
     | '(' a=expression b=for_if_clauses ')' { _Py_GeneratorExp(a, b, EXTRA) }
-~set[expr_ty]: '{' a=expressions_list '}' { _Py_Set(a, EXTRA) }
-~setcomp[expr_ty]:
+set[expr_ty]: '{' a=expressions_list '}' { _Py_Set(a, EXTRA) }
+setcomp[expr_ty]:
     | '{' a=expression b=for_if_clauses '}' { _Py_SetComp(a, b, EXTRA) }
-~dict[expr_ty]:
+dict[expr_ty]:
     | '{' a=[kvpairs] '}' { _Py_Dict(CHECK(get_keys(p, a)),
                                      CHECK(get_values(p, a)), EXTRA) }
-~dictcomp[expr_ty]:
+dictcomp[expr_ty]:
     | '{' a=kvpair b=for_if_clauses '}' { _Py_DictComp(a->key, a->value, b, EXTRA) }
-~kvpairs[asdl_seq*]: a=','.kvpair+ [','] { a }
-~kvpair[KeyValuePair*]:
+kvpairs[asdl_seq*]: a=','.kvpair+ [','] { a }
+kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { key_value_pair(p, NULL, a) }
     | a=expression ':' b=expression { key_value_pair(p, a, b) }
-~for_if_clauses[asdl_seq*]:
+for_if_clauses[asdl_seq*]:
     | a=(y=[ASYNC] 'for' a=star_targets 'in' b=disjunction c=('if' z=disjunction { z })*
         { _Py_comprehension(a, b, c, (y == NULL) ? 0 : 1, p->arena) })+ { a }
 
-~yield_expr[expr_ty]:
+yield_expr[expr_ty]:
     | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }
     | 'yield' a=[expressions] { _Py_Yield(a, EXTRA) }
 
-~arguments[expr_ty]:
+arguments[expr_ty]:
     | a=args [','] { a }
-~args[expr_ty]:
+args[expr_ty]:
     | a=starred_expression b=[',' c=args { c }] {
         _Py_Call(CONSTRUCTOR(p),
                  (b) ? CHECK(seq_insert_in_front(p, a, ((expr_ty) b)->v.Call.args))
@@ -411,58 +411,58 @@ dotted_name[expr_ty]:
                      : CHECK(singleton_seq(p, a)),
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
-~kwargs[asdl_seq*]: a=','.kwarg+ { a }
-~starred_expression[expr_ty]:
+kwargs[asdl_seq*]: a=','.kwarg+ { a }
+starred_expression[expr_ty]:
     | '*' a=expression { _Py_Starred(a, Load, EXTRA) }
-~kwarg[KeywordOrStarred*]:
+kwarg[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
         keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, p->arena)), 1) }
     | a=starred_expression { keyword_or_starred(p, a, 0) }
     | '**' a=expression { keyword_or_starred(p, CHECK(_Py_keyword(NULL, a, p->arena)), 1) }
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
-~star_targets[expr_ty]:
+star_targets[expr_ty]:
     | a=star_target !',' { a }
     | a=star_target b=(',' c=star_target { c })* [','] {
         _Py_Tuple(CHECK(seq_insert_in_front(p, a, b)), Store, EXTRA) }
-~star_targets_seq[asdl_seq*]: a=','.star_target+ [','] { a }
-~star_target[expr_ty]:
+star_targets_seq[asdl_seq*]: a=','.star_target+ [','] { a }
+star_target[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(CHECK(set_expr_context(p, a, Store)), Store, EXTRA) }
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
     | star_atom
-~star_atom[expr_ty]:
+star_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=star_target ')' { set_expr_context(p, a, Store) }
     | '(' a=[star_targets_seq] ')' { _Py_Tuple(a, Store, EXTRA) }
     | '[' a=[star_targets_seq] ']' { _Py_List(a, Store, EXTRA) }
 
-~inside_paren_ann_assign_target[expr_ty]:
+inside_paren_ann_assign_target[expr_ty]:
     | ann_assign_subscript_attribute_target
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=inside_paren_ann_assign_target ')' { a }
 
-~ann_assign_subscript_attribute_target[expr_ty]:
+ann_assign_subscript_attribute_target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
 
-~del_targets[asdl_seq*]: a=','.del_target+ [','] { a }
-~del_target[expr_ty]:
+del_targets[asdl_seq*]: a=','.del_target+ [','] { a }
+del_target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Del, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Del, EXTRA) }
     | del_t_atom
-~del_t_atom[expr_ty]:
+del_t_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Del) }
     | '(' a=del_target ')' { set_expr_context(p, a, Del) }
     | '(' a=[del_targets] ')' { _Py_Tuple(a, Del, EXTRA) }
     | '[' a=[del_targets] ']' { _Py_List(a, Del, EXTRA) }
 
-~targets[asdl_seq*]: a=','.target+ [','] { a }
-~target[expr_ty]:
+targets[asdl_seq*]: a=','.target+ [','] { a }
+target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
     | t_atom
-~t_primary[expr_ty]:
+t_primary[expr_ty]:
     | a=t_primary '.' b=NAME &t_lookahead { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
     | a=t_primary b=slicing &t_lookahead { _Py_Subscript(a, b, Load, EXTRA) }
     | a=t_primary b=genexp &t_lookahead { _Py_Call(a, CHECK(singleton_seq(p, b)), NULL, EXTRA) }
@@ -472,8 +472,8 @@ dotted_name[expr_ty]:
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
     | a=atom &t_lookahead { a }
-~t_lookahead: '(' | '[' | '.'
-~t_atom[expr_ty]:
+t_lookahead: '(' | '[' | '.'
+t_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=target ')' { set_expr_context(p, a, Store) }
     | '(' b=[targets] ')' { _Py_Tuple(b, Store, EXTRA) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -9,7 +9,7 @@ simple_stmt[asdl_seq*]:
     | a=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
-small_stmt[stmt_ty]:
+~small_stmt[stmt_ty]:
     | assignment
     | e=expressions { _Py_Expr(e, EXTRA) }
     | &'return' return_stmt
@@ -250,19 +250,19 @@ lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
 lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
 lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
 
-disjunction[expr_ty]:
+~disjunction[expr_ty]:
     | a=conjunction b=('or' c=conjunction { c })+ { _Py_BoolOp(
         Or,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | conjunction
-conjunction[expr_ty]:
+~conjunction[expr_ty]:
     | a=inversion b=('and' c=inversion { c })+ { _Py_BoolOp(
         And,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | inversion
-inversion[expr_ty]:
+~inversion[expr_ty]:
     | 'not' a=inversion { _Py_UnaryOp(Not, a, EXTRA) }
     | comparison
 comparison[expr_ty]:
@@ -324,7 +324,7 @@ factor[expr_ty]:
 power[expr_ty]:
     | a=await_primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
     | await_primary
-await_primary[expr_ty]:
+~await_primary[expr_ty]:
     | AWAIT a=primary { _Py_Await(a, EXTRA) }
     | primary
 primary[expr_ty]:
@@ -350,7 +350,7 @@ slices[slice_ty]:
 slice[slice_ty]:
     | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, p->arena) }
     | a=expression { _Py_Index(a, p->arena) }
-atom[expr_ty]:
+~atom[expr_ty]:
     | NAME
     | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
     | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -9,7 +9,7 @@ simple_stmt[asdl_seq*]:
     | a=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
-~small_stmt[stmt_ty]:
+small_stmt[stmt_ty] (memo):
     | assignment
     | e=expressions { _Py_Expr(e, EXTRA) }
     | &'return' return_stmt
@@ -177,7 +177,7 @@ name_with_optional_default[NameDefaultPair*]:
 names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
 name_with_default[NameDefaultPair*]:
     | n=plain_name '=' e=expression { name_default_pair(p, n, e) }
-~plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
+plain_names[asdl_seq*] (memo): a=','.(plain_name !'=')+ { a }
 plain_name[arg_ty]:
     | a=NAME b=[':' z=annotation { z }] { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
 kwds[arg_ty]:
@@ -196,7 +196,7 @@ class_def_raw[stmt_ty]:
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
 
-~block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
+block[asdl_seq*] (memo): NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
 
 expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
 expressions[expr_ty]:
@@ -204,7 +204,7 @@ expressions[expr_ty]:
         _Py_Tuple(CHECK(seq_insert_in_front(p, a, b)), Load, EXTRA) }
     | a=star_expression ',' { _Py_Tuple(CHECK(singleton_seq(p, a)), Load, EXTRA) }
     | star_expression
-~star_expression[expr_ty]:
+star_expression[expr_ty] (memo):
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | expression
 
@@ -216,7 +216,7 @@ named_expression[expr_ty]:
     | a=NAME ':=' b=expression { _Py_NamedExpr(CHECK(set_expr_context(p, a, Store)), b, EXTRA) }
     | expression
 annotated_rhs[expr_ty]: yield_expr | expressions
-~expression[expr_ty]:
+expression[expr_ty] (memo):
     | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
@@ -250,19 +250,19 @@ lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
 lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
 lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
 
-~disjunction[expr_ty]:
+disjunction[expr_ty] (memo):
     | a=conjunction b=('or' c=conjunction { c })+ { _Py_BoolOp(
         Or,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | conjunction
-~conjunction[expr_ty]:
+conjunction[expr_ty] (memo):
     | a=inversion b=('and' c=inversion { c })+ { _Py_BoolOp(
         And,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | inversion
-~inversion[expr_ty]:
+inversion[expr_ty] (memo):
     | 'not' a=inversion { _Py_UnaryOp(Not, a, EXTRA) }
     | comparison
 comparison[expr_ty]:
@@ -316,7 +316,7 @@ term[expr_ty]:
     | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
     | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA) }
     | factor
-~factor[expr_ty]:
+factor[expr_ty] (memo):
     | '+' a=factor { _Py_UnaryOp(UAdd, a, EXTRA) }
     | '-' a=factor { _Py_UnaryOp(USub, a, EXTRA) }
     | '~' a=factor { _Py_UnaryOp(Invert, a, EXTRA) }
@@ -324,7 +324,7 @@ term[expr_ty]:
 power[expr_ty]:
     | a=await_primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
     | await_primary
-~await_primary[expr_ty]:
+await_primary[expr_ty] (memo):
     | AWAIT a=primary { _Py_Await(a, EXTRA) }
     | primary
 primary[expr_ty]:
@@ -350,7 +350,7 @@ slices[slice_ty]:
 slice[slice_ty]:
     | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, p->arena) }
     | a=expression { _Py_Index(a, p->arena) }
-~atom[expr_ty]:
+atom[expr_ty] (memo):
     | NAME
     | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
     | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
@@ -392,7 +392,7 @@ yield_expr[expr_ty]:
     | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }
     | 'yield' a=[expressions] { _Py_Yield(a, EXTRA) }
 
-~arguments[expr_ty]:
+arguments[expr_ty] (memo):
     | a=args [','] { a }
 args[expr_ty]:
     | a=starred_expression b=[',' c=args { c }] {

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -177,7 +177,7 @@ name_with_optional_default[NameDefaultPair*]:
 names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
 name_with_default[NameDefaultPair*]:
     | n=plain_name '=' e=expression { name_default_pair(p, n, e) }
-plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
+~plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
 plain_name[arg_ty]:
     | a=NAME b=[':' z=annotation { z }] { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
 kwds[arg_ty]:
@@ -196,7 +196,7 @@ class_def_raw[stmt_ty]:
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
 
-block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
+~block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
 
 expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
 expressions[expr_ty]:
@@ -204,7 +204,7 @@ expressions[expr_ty]:
         _Py_Tuple(CHECK(seq_insert_in_front(p, a, b)), Load, EXTRA) }
     | a=star_expression ',' { _Py_Tuple(CHECK(singleton_seq(p, a)), Load, EXTRA) }
     | star_expression
-star_expression[expr_ty]:
+~star_expression[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | expression
 
@@ -216,7 +216,7 @@ named_expression[expr_ty]:
     | a=NAME ':=' b=expression { _Py_NamedExpr(CHECK(set_expr_context(p, a, Store)), b, EXTRA) }
     | expression
 annotated_rhs[expr_ty]: yield_expr | expressions
-expression[expr_ty]:
+~expression[expr_ty]:
     | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
@@ -316,7 +316,7 @@ term[expr_ty]:
     | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
     | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA) }
     | factor
-factor[expr_ty]:
+~factor[expr_ty]:
     | '+' a=factor { _Py_UnaryOp(UAdd, a, EXTRA) }
     | '-' a=factor { _Py_UnaryOp(USub, a, EXTRA) }
     | '~' a=factor { _Py_UnaryOp(Invert, a, EXTRA) }
@@ -392,7 +392,7 @@ yield_expr[expr_ty]:
     | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }
     | 'yield' a=[expressions] { _Py_Yield(a, EXTRA) }
 
-arguments[expr_ty]:
+~arguments[expr_ty]:
     | a=args [','] { a }
 args[expr_ty]:
     | a=starred_expression b=[',' c=args { c }] {

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -32,7 +32,7 @@ statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
     | &'try' try_stmt
     | &'while' while_stmt
 
-assignment:
+~assignment:
     | a=NAME ':' b=expression c=['=' d=annotated_rhs { d }] {
         _Py_AnnAssign(CHECK(set_expr_context(p, a, Store)), b, c, 1, EXTRA) }
     | a=('(' b=inside_paren_ann_assign_target ')' { b }
@@ -43,7 +43,7 @@ assignment:
     | a=target b=augassign c=(yield_expr | expressions) {
          _Py_AugAssign(a, b->kind, c, EXTRA) }
 
-augassign[AugOperator*]:
+~augassign[AugOperator*]:
     | '+=' {augoperator(p, Add)}
     | '-=' {augoperator(p, Sub)}
     | '*=' {augoperator(p, Mult)}
@@ -75,19 +75,19 @@ augassign[AugOperator*]:
         _Py_ImportFrom(b->v.Name.id, c, seq_count_dots(a), EXTRA) }
     | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
         _Py_ImportFrom(NULL, b, seq_count_dots(a), EXTRA) }
-import_from_targets[asdl_seq*]:
+~import_from_targets[asdl_seq*]:
     | '(' a=import_from_as_names ')' { a }
     | import_from_as_names
     | '*' { singleton_seq(p, CHECK(alias_for_star(p))) }
-import_from_as_names[asdl_seq*]:
+~import_from_as_names[asdl_seq*]:
     | a=','.import_from_as_name+ [','] { a }
-import_from_as_name[alias_ty]:
+~import_from_as_name[alias_ty]:
     | a=NAME b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                p->arena) }
-dotted_as_names[asdl_seq*]:
+~dotted_as_names[asdl_seq*]:
     | a=','.dotted_as_name+ { a }
-dotted_as_name[alias_ty]:
+~dotted_as_name[alias_ty]:
     | a=dotted_name b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                       (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                       p->arena) }
@@ -121,7 +121,7 @@ dotted_name[expr_ty]:
         _Py_With(a, b, NULL, EXTRA) }
     | 'with' a=','.with_item+ ':' b=block {
         _Py_With(a, b, NULL, EXTRA) }
-with_item[withitem_ty]:
+~with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, o, p->arena) }
 
 ~try_stmt[stmt_ty]:
@@ -133,7 +133,7 @@ with_item[withitem_ty]:
     | 'except' ':' b=block { _Py_ExceptHandler(NULL, NULL, b, EXTRA) }
 ~finally_block[asdl_seq*]: 'finally' ':' a=block { a }
 
-return_stmt[stmt_ty]:
+~return_stmt[stmt_ty]:
     | 'return' a=[expressions] { _Py_Return(a, EXTRA) }
 
 ~raise_stmt[stmt_ty]:
@@ -154,7 +154,7 @@ return_stmt[stmt_ty]:
                         (params) ? params : CHECK(empty_arguments(p)),
                         b, NULL, a, NULL, EXTRA) }
 
-parameters[arguments_ty]:
+~parameters[arguments_ty]:
     | a=slash_without_default b=[',' x=plain_names { x }] c=[',' y=names_with_default { y }] d=[',' z=[star_etc] { z }] {
         make_arguments(p, a, NULL, b, c, d) }
     | a=slash_with_default b=[',' y=names_with_default { y }] c=[',' z=[star_etc] { z }] {
@@ -163,26 +163,26 @@ parameters[arguments_ty]:
         make_arguments(p, NULL, NULL, a, b, c) }
     | a=names_with_default b=[',' z=[star_etc] { z }] { make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=star_etc { make_arguments(p, NULL, NULL, NULL, NULL, a) }
-slash_without_default[asdl_seq*]: a=plain_names ',' '/' { a }
-slash_with_default[SlashWithDefault*]: a=[n=plain_names ',' { n }] b=names_with_default ',' '/' {
+~slash_without_default[asdl_seq*]: a=plain_names ',' '/' { a }
+~slash_with_default[SlashWithDefault*]: a=[n=plain_names ',' { n }] b=names_with_default ',' '/' {
     slash_with_default(p, a, b) }
-star_etc[StarEtc*]:
+~star_etc[StarEtc*]:
     | '*' a=plain_name b=name_with_optional_default* c=[',' d=kwds { d }] [','] {
         star_etc(p, a, b, c) }
     | '*' b=name_with_optional_default+ c=[',' d=kwds { d }] [','] {
         star_etc(p, NULL, b, c) }
     | a=kwds [','] { star_etc(p, NULL, NULL, a) }
-name_with_optional_default[NameDefaultPair*]:
+~name_with_optional_default[NameDefaultPair*]:
     | ',' a=plain_name b=['=' e=expression { e }] { name_default_pair(p, a, b) }
-names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
-name_with_default[NameDefaultPair*]:
+~names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
+~name_with_default[NameDefaultPair*]:
     | n=plain_name '=' e=expression { name_default_pair(p, n, e) }
-plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
-plain_name[arg_ty]:
+~plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
+~plain_name[arg_ty]:
     | a=NAME b=[':' z=annotation { z }] { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
-kwds[arg_ty]:
+~kwds[arg_ty]:
     | '**' a=plain_name { a }
-annotation[expr_ty]: expression
+~annotation[expr_ty]: expression
 
 ~decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
 
@@ -196,34 +196,34 @@ annotation[expr_ty]: expression
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
 
-block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
+~block[asdl_seq*]: NEWLINE INDENT a=statements DEDENT { a } | simple_stmt
 
-expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
-expressions[expr_ty]:
+~expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
+~expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
         _Py_Tuple(CHECK(seq_insert_in_front(p, a, b)), Load, EXTRA) }
     | a=star_expression ',' { _Py_Tuple(CHECK(singleton_seq(p, a)), Load, EXTRA) }
     | star_expression
-star_expression[expr_ty]:
+~star_expression[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | expression
 
-star_named_expressions[asdl_seq*]: a=','.star_named_expression+ [','] { a }
-star_named_expression[expr_ty]:
+~star_named_expressions[asdl_seq*]: a=','.star_named_expression+ [','] { a }
+~star_named_expression[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | named_expression
-named_expression[expr_ty]:
+~named_expression[expr_ty]:
     | a=NAME ':=' b=expression { _Py_NamedExpr(CHECK(set_expr_context(p, a, Store)), b, EXTRA) }
     | expression
-annotated_rhs[expr_ty]: yield_expr | expressions
-expression[expr_ty]:
+~annotated_rhs[expr_ty]: yield_expr | expressions
+~expression[expr_ty]:
     | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
 
-lambdef[expr_ty]:
+~lambdef[expr_ty]:
     | 'lambda' a=[lambda_parameters] ':' b=expression { _Py_Lambda((a) ? a : CHECK(empty_arguments(p)), b, EXTRA) }
-lambda_parameters[arguments_ty]:
+~lambda_parameters[arguments_ty]:
     | a=lambda_slash_without_default b=[',' x=lambda_plain_names { x }] c=[',' y=lambda_names_with_default { y }] d=[',' z=[lambda_star_etc] { z }] {
         make_arguments(p, a, NULL, b, c, d) }
     | a=lambda_slash_with_default b=[',' y=lambda_names_with_default { y }] c=[',' z=[lambda_star_etc] { z }] {
@@ -232,44 +232,44 @@ lambda_parameters[arguments_ty]:
         make_arguments(p, NULL, NULL, a, b, c) }
     | a=lambda_names_with_default b=[',' z=[lambda_star_etc] { z }] { make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=lambda_star_etc { make_arguments(p, NULL, NULL, NULL, NULL, a) }
-lambda_slash_without_default[asdl_seq*]: a=lambda_plain_names ',' '/' { a }
-lambda_slash_with_default[SlashWithDefault*]: a=[n=lambda_plain_names ',' { n }] b=lambda_names_with_default ',' '/' {
+~lambda_slash_without_default[asdl_seq*]: a=lambda_plain_names ',' '/' { a }
+~lambda_slash_with_default[SlashWithDefault*]: a=[n=lambda_plain_names ',' { n }] b=lambda_names_with_default ',' '/' {
     slash_with_default(p, a, b) }
-lambda_star_etc[StarEtc*]:
+~lambda_star_etc[StarEtc*]:
     | '*' a=lambda_plain_name b=lambda_name_with_optional_default* c=[',' d=lambda_kwds { d }] [','] {
         star_etc(p, a, b, c) }
     | '*' b=lambda_name_with_optional_default+ c=[',' d=lambda_kwds { d }] [','] {
         star_etc(p, NULL, b, c) }
     | a=lambda_kwds [','] { star_etc(p, NULL, NULL, a) }
-lambda_name_with_optional_default[NameDefaultPair*]:
+~lambda_name_with_optional_default[NameDefaultPair*]:
     | ',' a=lambda_plain_name b=['=' e=expression { e }] { name_default_pair(p, a, b) }
-lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
-lambda_name_with_default[NameDefaultPair*]:
+~lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
+~lambda_name_with_default[NameDefaultPair*]:
     | n=lambda_plain_name '=' e=expression { name_default_pair(p, n, e) }
-lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
-lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
-lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
+~lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
+~lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
+~lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
 
-disjunction[expr_ty]:
+~disjunction[expr_ty]:
     | a=conjunction b=('or' c=conjunction { c })+ { _Py_BoolOp(
         Or,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | conjunction
-conjunction[expr_ty]:
+~conjunction[expr_ty]:
     | a=inversion b=('and' c=inversion { c })+ { _Py_BoolOp(
         And,
         CHECK(seq_insert_in_front(p, a, b)),
         EXTRA) }
     | inversion
-inversion[expr_ty]:
+~inversion[expr_ty]:
     | 'not' a=inversion { _Py_UnaryOp(Not, a, EXTRA) }
     | comparison
-comparison[expr_ty]:
+~comparison[expr_ty]:
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
         _Py_Compare(a, CHECK(get_cmpops(p, b)), CHECK(get_exprs(p, b)), EXTRA) }
     | bitwise_or
-compare_op_bitwise_or_pair[CmpopExprPair*]:
+~compare_op_bitwise_or_pair[CmpopExprPair*]:
     | eq_bitwise_or
     | noteq_bitwise_or
     | lte_bitwise_or
@@ -280,54 +280,54 @@ compare_op_bitwise_or_pair[CmpopExprPair*]:
     | in_bitwise_or
     | isnot_bitwise_or
     | is_bitwise_or
-eq_bitwise_or[CmpopExprPair*]: '==' a=bitwise_or { cmpop_expr_pair(p, Eq, a) }
-noteq_bitwise_or[CmpopExprPair*]: '!=' a=bitwise_or { cmpop_expr_pair(p, NotEq, a) }
-lte_bitwise_or[CmpopExprPair*]: '<=' a=bitwise_or { cmpop_expr_pair(p, LtE, a) }
-lt_bitwise_or[CmpopExprPair*]: '<' a=bitwise_or { cmpop_expr_pair(p, Lt, a) }
-gte_bitwise_or[CmpopExprPair*]: '>=' a=bitwise_or { cmpop_expr_pair(p, GtE, a) }
-gt_bitwise_or[CmpopExprPair*]: '>' a=bitwise_or { cmpop_expr_pair(p, Gt, a) }
-notin_bitwise_or[CmpopExprPair*]: 'not' 'in' a=bitwise_or { cmpop_expr_pair(p, NotIn, a) }
-in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { cmpop_expr_pair(p, In, a) }
-isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { cmpop_expr_pair(p, IsNot, a) }
-is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { cmpop_expr_pair(p, Is, a) }
+~eq_bitwise_or[CmpopExprPair*]: '==' a=bitwise_or { cmpop_expr_pair(p, Eq, a) }
+~noteq_bitwise_or[CmpopExprPair*]: '!=' a=bitwise_or { cmpop_expr_pair(p, NotEq, a) }
+~lte_bitwise_or[CmpopExprPair*]: '<=' a=bitwise_or { cmpop_expr_pair(p, LtE, a) }
+~lt_bitwise_or[CmpopExprPair*]: '<' a=bitwise_or { cmpop_expr_pair(p, Lt, a) }
+~gte_bitwise_or[CmpopExprPair*]: '>=' a=bitwise_or { cmpop_expr_pair(p, GtE, a) }
+~gt_bitwise_or[CmpopExprPair*]: '>' a=bitwise_or { cmpop_expr_pair(p, Gt, a) }
+~notin_bitwise_or[CmpopExprPair*]: 'not' 'in' a=bitwise_or { cmpop_expr_pair(p, NotIn, a) }
+~in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { cmpop_expr_pair(p, In, a) }
+~isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { cmpop_expr_pair(p, IsNot, a) }
+~is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { cmpop_expr_pair(p, Is, a) }
 
-bitwise_or[expr_ty]:
+~bitwise_or[expr_ty]:
     | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA) }
     | bitwise_xor
-bitwise_xor[expr_ty]:
+~bitwise_xor[expr_ty]:
     | a=bitwise_xor '^' b=bitwise_and { _Py_BinOp(a, BitXor, b, EXTRA) }
     | bitwise_and
-bitwise_and[expr_ty]:
+~bitwise_and[expr_ty]:
     | a=bitwise_and '&' b=shift_expr { _Py_BinOp(a, BitAnd, b, EXTRA) }
     | shift_expr
-shift_expr[expr_ty]:
+~shift_expr[expr_ty]:
     | a=shift_expr '<<' b=sum { _Py_BinOp(a, LShift, b, EXTRA) }
     | a=shift_expr '>>' b=sum { _Py_BinOp(a, RShift, b, EXTRA) }
     | sum
 
-sum[expr_ty]:
+~sum[expr_ty]:
     | a=sum '+' b=term { _Py_BinOp(a, Add, b, EXTRA) }
     | a=sum '-' b=term { _Py_BinOp(a, Sub, b, EXTRA) }
     | term
-term[expr_ty]:
+~term[expr_ty]:
     | a=term '*' b=factor { _Py_BinOp(a, Mult, b, EXTRA) }
     | a=term '/' b=factor { _Py_BinOp(a, Div, b, EXTRA) }
     | a=term '//' b=factor { _Py_BinOp(a, FloorDiv, b, EXTRA) }
     | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
     | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA) }
     | factor
-factor[expr_ty]:
+~factor[expr_ty]:
     | '+' a=factor { _Py_UnaryOp(UAdd, a, EXTRA) }
     | '-' a=factor { _Py_UnaryOp(USub, a, EXTRA) }
     | '~' a=factor { _Py_UnaryOp(Invert, a, EXTRA) }
     | power
-power[expr_ty]:
+~power[expr_ty]:
     | a=await_primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
     | await_primary
-await_primary[expr_ty]:
+~await_primary[expr_ty]:
     | AWAIT a=primary { _Py_Await(a, EXTRA) }
     | primary
-primary[expr_ty]:
+~primary[expr_ty]:
     | a=primary '.' b=NAME { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
     | a=primary b=genexp { _Py_Call(a, CHECK(singleton_seq(p, b)), NULL, EXTRA) }
     | a=primary '(' b=[arguments] ')' {
@@ -338,19 +338,19 @@ primary[expr_ty]:
     | a=primary b=slicing { _Py_Subscript(a, b, Load, EXTRA) }
     | atom
 
-slicing[slice_ty]:
+~slicing[slice_ty]:
     | '[' b=expression ']' { _Py_Index(b, p->arena) }
     | '[' b=slice_expressions ']' { b }
     | '[' b=slices ']' { b }
-slice_expressions[slice_ty]:
+~slice_expressions[slice_ty]:
     | a=','.expression+ [','] { _Py_Index(_Py_Tuple(a, Load, EXTRA), p->arena) }
-slices[slice_ty]:
+~slices[slice_ty]:
     | a=slice !',' { a }
     | a=','.slice+ [','] { _Py_ExtSlice(a, p->arena) }
-slice[slice_ty]:
+~slice[slice_ty]:
     | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, p->arena) }
     | a=expression { _Py_Index(a, p->arena) }
-atom[expr_ty]:
+~atom[expr_ty]:
     | NAME
     | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
     | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
@@ -362,39 +362,39 @@ atom[expr_ty]:
     | &'{' (dict | set | dictcomp | setcomp)
     | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
-list[expr_ty]:
+~list[expr_ty]:
     | '[' a=[star_named_expressions] ']' { _Py_List(a, Load, EXTRA) }
-listcomp[expr_ty]:
+~listcomp[expr_ty]:
     | '[' a=named_expression b=for_if_clauses ']' { _Py_ListComp(a, b, EXTRA) }
-tuple[expr_ty]:
+~tuple[expr_ty]:
     | '(' a=[y=star_named_expression ',' z=[star_named_expressions] { seq_insert_in_front(p, y, z) } ] ')' {
         _Py_Tuple(a, Load, EXTRA) }
-group[expr_ty]: '(' a=(yield_expr | named_expression) ')' { a }
-genexp[expr_ty]:
+~group[expr_ty]: '(' a=(yield_expr | named_expression) ')' { a }
+~genexp[expr_ty]:
     | '(' a=expression b=for_if_clauses ')' { _Py_GeneratorExp(a, b, EXTRA) }
-set[expr_ty]: '{' a=expressions_list '}' { _Py_Set(a, EXTRA) }
-setcomp[expr_ty]:
+~set[expr_ty]: '{' a=expressions_list '}' { _Py_Set(a, EXTRA) }
+~setcomp[expr_ty]:
     | '{' a=expression b=for_if_clauses '}' { _Py_SetComp(a, b, EXTRA) }
-dict[expr_ty]:
+~dict[expr_ty]:
     | '{' a=[kvpairs] '}' { _Py_Dict(CHECK(get_keys(p, a)),
                                      CHECK(get_values(p, a)), EXTRA) }
-dictcomp[expr_ty]:
+~dictcomp[expr_ty]:
     | '{' a=kvpair b=for_if_clauses '}' { _Py_DictComp(a->key, a->value, b, EXTRA) }
-kvpairs[asdl_seq*]: a=','.kvpair+ [','] { a }
-kvpair[KeyValuePair*]:
+~kvpairs[asdl_seq*]: a=','.kvpair+ [','] { a }
+~kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { key_value_pair(p, NULL, a) }
     | a=expression ':' b=expression { key_value_pair(p, a, b) }
-for_if_clauses[asdl_seq*]:
+~for_if_clauses[asdl_seq*]:
     | a=(y=[ASYNC] 'for' a=star_targets 'in' b=disjunction c=('if' z=disjunction { z })*
         { _Py_comprehension(a, b, c, (y == NULL) ? 0 : 1, p->arena) })+ { a }
 
-yield_expr[expr_ty]:
+~yield_expr[expr_ty]:
     | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }
     | 'yield' a=[expressions] { _Py_Yield(a, EXTRA) }
 
-arguments[expr_ty]:
+~arguments[expr_ty]:
     | a=args [','] { a }
-args[expr_ty]:
+~args[expr_ty]:
     | a=starred_expression b=[',' c=args { c }] {
         _Py_Call(CONSTRUCTOR(p),
                  (b) ? CHECK(seq_insert_in_front(p, a, ((expr_ty) b)->v.Call.args))
@@ -411,58 +411,58 @@ args[expr_ty]:
                      : CHECK(singleton_seq(p, a)),
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
-kwargs[asdl_seq*]: a=','.kwarg+ { a }
-starred_expression[expr_ty]:
+~kwargs[asdl_seq*]: a=','.kwarg+ { a }
+~starred_expression[expr_ty]:
     | '*' a=expression { _Py_Starred(a, Load, EXTRA) }
-kwarg[KeywordOrStarred*]:
+~kwarg[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
         keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, p->arena)), 1) }
     | a=starred_expression { keyword_or_starred(p, a, 0) }
     | '**' a=expression { keyword_or_starred(p, CHECK(_Py_keyword(NULL, a, p->arena)), 1) }
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
-star_targets[expr_ty]:
+~star_targets[expr_ty]:
     | a=star_target !',' { a }
     | a=star_target b=(',' c=star_target { c })* [','] {
         _Py_Tuple(CHECK(seq_insert_in_front(p, a, b)), Store, EXTRA) }
-star_targets_seq[asdl_seq*]: a=','.star_target+ [','] { a }
-star_target[expr_ty]:
+~star_targets_seq[asdl_seq*]: a=','.star_target+ [','] { a }
+~star_target[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(CHECK(set_expr_context(p, a, Store)), Store, EXTRA) }
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
     | star_atom
-star_atom[expr_ty]:
+~star_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=star_target ')' { set_expr_context(p, a, Store) }
     | '(' a=[star_targets_seq] ')' { _Py_Tuple(a, Store, EXTRA) }
     | '[' a=[star_targets_seq] ']' { _Py_List(a, Store, EXTRA) }
 
-inside_paren_ann_assign_target[expr_ty]:
+~inside_paren_ann_assign_target[expr_ty]:
     | ann_assign_subscript_attribute_target
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=inside_paren_ann_assign_target ')' { a }
 
-ann_assign_subscript_attribute_target[expr_ty]:
+~ann_assign_subscript_attribute_target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
 
-del_targets[asdl_seq*]: a=','.del_target+ [','] { a }
-del_target[expr_ty]:
+~del_targets[asdl_seq*]: a=','.del_target+ [','] { a }
+~del_target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Del, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Del, EXTRA) }
     | del_t_atom
-del_t_atom[expr_ty]:
+~del_t_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Del) }
     | '(' a=del_target ')' { set_expr_context(p, a, Del) }
     | '(' a=[del_targets] ')' { _Py_Tuple(a, Del, EXTRA) }
     | '[' a=[del_targets] ']' { _Py_List(a, Del, EXTRA) }
 
-targets[asdl_seq*]: a=','.target+ [','] { a }
-target[expr_ty]:
+~targets[asdl_seq*]: a=','.target+ [','] { a }
+~target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary b=slicing !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
     | t_atom
-t_primary[expr_ty]:
+~t_primary[expr_ty]:
     | a=t_primary '.' b=NAME &t_lookahead { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
     | a=t_primary b=slicing &t_lookahead { _Py_Subscript(a, b, Load, EXTRA) }
     | a=t_primary b=genexp &t_lookahead { _Py_Call(a, CHECK(singleton_seq(p, b)), NULL, EXTRA) }
@@ -472,8 +472,8 @@ t_primary[expr_ty]:
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
     | a=atom &t_lookahead { a }
-t_lookahead: '(' | '[' | '.'
-t_atom[expr_ty]:
+~t_lookahead: '(' | '[' | '.'
+~t_atom[expr_ty]:
     | a=NAME { set_expr_context(p, a, Store) }
     | '(' a=target ')' { set_expr_context(p, a, Store) }
     | '(' b=[targets] ')' { _Py_Tuple(b, Store, EXTRA) }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -1,15 +1,15 @@
 # Simplified grammar for Python
 
-start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+~start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
 statements[asdl_seq*]: a=statement+ { seq_flatten(p, a) }
 
-statement[asdl_seq*]: a=compound_stmt { singleton_seq(p, a) } | simple_stmt
-simple_stmt[asdl_seq*]:
+~statement[asdl_seq*]: a=compound_stmt { singleton_seq(p, a) } | simple_stmt
+~simple_stmt[asdl_seq*]:
     | a=small_stmt !';' NEWLINE { singleton_seq(p, a) } # Not needed, there for speedup
     | a=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
-small_stmt[stmt_ty]:
+~small_stmt[stmt_ty]:
     | assignment
     | e=expressions { _Py_Expr(e, EXTRA) }
     | &'return' return_stmt
@@ -23,7 +23,7 @@ small_stmt[stmt_ty]:
     | 'continue' { _Py_Continue(EXTRA) }
     | &'global' global_stmt
     | &'nonlocal' nonlocal_stmt
-compound_stmt[stmt_ty]:
+~compound_stmt[stmt_ty]:
     | &('def' | '@' | ASYNC) function_def
     | &'if' if_stmt
     | &('class' | '@') class_def
@@ -58,19 +58,19 @@ augassign[AugOperator*]:
     | '**=' {augoperator(p, Pow)}
     | '//=' {augoperator(p, FloorDiv)}
 
-global_stmt[stmt_ty]: 'global' a=','.NAME+ { _Py_Global(CHECK(map_names_to_ids(p, a)), EXTRA) }
-nonlocal_stmt[stmt_ty]: 'nonlocal' a=','.NAME+ { _Py_Nonlocal(CHECK(map_names_to_ids(p, a)), EXTRA) }
+~global_stmt[stmt_ty]: 'global' a=','.NAME+ { _Py_Global(CHECK(map_names_to_ids(p, a)), EXTRA) }
+~nonlocal_stmt[stmt_ty]: 'nonlocal' a=','.NAME+ { _Py_Nonlocal(CHECK(map_names_to_ids(p, a)), EXTRA) }
 
-yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
+~yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
 
-assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
+~assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
 
-del_stmt[stmt_ty]: 'del' a=del_targets { _Py_Delete(a, EXTRA) }
+~del_stmt[stmt_ty]: 'del' a=del_targets { _Py_Delete(a, EXTRA) }
 
-import_stmt[stmt_ty]: import_name | import_from
-import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
+~import_stmt[stmt_ty]: import_name | import_from
+~import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
-import_from[stmt_ty]:
+~import_from[stmt_ty]:
     | 'from' a=('.' | '...')* b=dotted_name 'import' c=import_from_targets {
         _Py_ImportFrom(b->v.Name.id, c, seq_count_dots(a), EXTRA) }
     | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
@@ -95,24 +95,24 @@ dotted_name[expr_ty]:
     | a=dotted_name '.' b=NAME { join_names_with_dot(p, a, b) }
     | NAME
 
-if_stmt[stmt_ty]:
+~if_stmt[stmt_ty]:
     | 'if' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK(singleton_seq(p, c)), EXTRA) }
     | 'if' a=named_expression ':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
-elif_stmt[stmt_ty]:
+~elif_stmt[stmt_ty]:
     | 'elif' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK(singleton_seq(p, c)), EXTRA) }
     | 'elif' a=named_expression ':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
-else_block[asdl_seq*]: 'else' ':' b=block { b }
+~else_block[asdl_seq*]: 'else' ':' b=block { b }
 
-while_stmt[stmt_ty]:
+~while_stmt[stmt_ty]:
     | 'while' a=named_expression ':' b=block c=[else_block] { _Py_While(a, b, c, EXTRA) }
 
-for_stmt[stmt_ty]:
+~for_stmt[stmt_ty]:
     | ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block el=[else_block] {
         _Py_AsyncFor(t, ex, b, el, NULL, EXTRA) }
     | 'for' t=star_targets 'in' ex=expressions ':' b=block el=[else_block] {
         _Py_For(t, ex, b, el, NULL, EXTRA) }
 
-with_stmt[stmt_ty]:
+~with_stmt[stmt_ty]:
     | ASYNC 'with' '(' a=','.with_item+ ')' ':' b=block {
         _Py_AsyncWith(a, b, NULL, EXTRA) }
     | ASYNC 'with' a=','.with_item+ ':' b=block {
@@ -124,27 +124,27 @@ with_stmt[stmt_ty]:
 with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, o, p->arena) }
 
-try_stmt[stmt_ty]:
+~try_stmt[stmt_ty]:
     | 'try' ':' b=block f=finally_block { _Py_Try(b, NULL, NULL, f, EXTRA) }
     | 'try' ':' b=block ex=except_block+ el=[else_block] f=[finally_block] { _Py_Try(b, ex, el, f, EXTRA) }
-except_block[excepthandler_ty]:
+~except_block[excepthandler_ty]:
     | 'except' e=expression t=['as' z=target { z }] ':' b=block {
         _Py_ExceptHandler(e, (t) ? ((expr_ty) t)->v.Name.id : NULL, b, EXTRA) }
     | 'except' ':' b=block { _Py_ExceptHandler(NULL, NULL, b, EXTRA) }
-finally_block[asdl_seq*]: 'finally' ':' a=block { a }
+~finally_block[asdl_seq*]: 'finally' ':' a=block { a }
 
 return_stmt[stmt_ty]:
     | 'return' a=[expressions] { _Py_Return(a, EXTRA) }
 
-raise_stmt[stmt_ty]:
+~raise_stmt[stmt_ty]:
     | 'raise' a=expression b=['from' z=expression { z }] { _Py_Raise(a, b, EXTRA) }
     | 'raise' { _Py_Raise(NULL, NULL, EXTRA) }
 
-function_def[stmt_ty]:
+~function_def[stmt_ty]:
     | d=decorators f=function_def_raw { function_def_decorators(p, d, f) }
     | function_def_raw
 
-function_def_raw[stmt_ty]:
+~function_def_raw[stmt_ty]:
     | ASYNC 'def' n=NAME '(' params=[parameters] ')' a=['->' z=annotation { z }] ':' b=block {
         _Py_AsyncFunctionDef(n->v.Name.id,
                              (params) ? params : CHECK(empty_arguments(p)),
@@ -184,12 +184,12 @@ kwds[arg_ty]:
     | '**' a=plain_name { a }
 annotation[expr_ty]: expression
 
-decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
+~decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
 
-class_def[stmt_ty]:
+~class_def[stmt_ty]:
     | a=decorators b=class_def_raw { class_def_decorators(p, a, b) }
     | class_def_raw
-class_def_raw[stmt_ty]:
+~class_def_raw[stmt_ty]:
     | 'class' a=NAME b=['(' z=[arguments] ')' { z }] ':' c=block {
         _Py_ClassDef(a->v.Name.id,
                      (b) ? ((expr_ty) b)->v.Call.args : NULL,

--- a/peg_parser/parse.c
+++ b/peg_parser/parse.c
@@ -735,6 +735,8 @@ static stmt_ty
 small_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
+    if (is_memoized(p, small_stmt_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -948,6 +950,7 @@ small_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, small_stmt_type, res);
     return res;
 }
 
@@ -4546,6 +4549,8 @@ static expr_ty
 disjunction_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, disjunction_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4592,6 +4597,7 @@ disjunction_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, disjunction_type, res);
     return res;
 }
 
@@ -4600,6 +4606,8 @@ static expr_ty
 conjunction_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, conjunction_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4646,6 +4654,7 @@ conjunction_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, conjunction_type, res);
     return res;
 }
 
@@ -4654,6 +4663,8 @@ static expr_ty
 inversion_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, inversion_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4700,6 +4711,7 @@ inversion_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, inversion_type, res);
     return res;
 }
 
@@ -6006,6 +6018,8 @@ static expr_ty
 await_primary_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, await_primary_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6052,6 +6066,7 @@ await_primary_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, await_primary_type, res);
     return res;
 }
 
@@ -6444,6 +6459,8 @@ static expr_ty
 atom_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, atom_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6619,6 +6636,7 @@ atom_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, atom_type, res);
     return res;
 }
 

--- a/peg_parser/parse.c
+++ b/peg_parser/parse.c
@@ -1072,8 +1072,6 @@ static void *
 assignment_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, assignment_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1199,7 +1197,6 @@ assignment_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, assignment_type, res);
     return res;
 }
 
@@ -1221,8 +1218,6 @@ static AugOperator*
 augassign_rule(Parser *p)
 {
     AugOperator* res = NULL;
-    if (is_memoized(p, augassign_type, &res))
-        return res;
     int mark = p->mark;
     { // '+='
         void *literal;
@@ -1408,7 +1403,6 @@ augassign_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, augassign_type, res);
     return res;
 }
 
@@ -1793,8 +1787,6 @@ static asdl_seq*
 import_from_targets_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, import_from_targets_type, &res))
-        return res;
     int mark = p->mark;
     { // '(' import_from_as_names ')'
         asdl_seq* a;
@@ -1843,7 +1835,6 @@ import_from_targets_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, import_from_targets_type, res);
     return res;
 }
 
@@ -1852,8 +1843,6 @@ static asdl_seq*
 import_from_as_names_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, import_from_as_names_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.import_from_as_name+ ','?
         asdl_seq * a;
@@ -1874,7 +1863,6 @@ import_from_as_names_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, import_from_as_names_type, res);
     return res;
 }
 
@@ -1883,8 +1871,6 @@ static alias_ty
 import_from_as_name_rule(Parser *p)
 {
     alias_ty res = NULL;
-    if (is_memoized(p, import_from_as_name_type, &res))
-        return res;
     int mark = p->mark;
     { // NAME ['as' NAME]
         expr_ty a;
@@ -1905,7 +1891,6 @@ import_from_as_name_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, import_from_as_name_type, res);
     return res;
 }
 
@@ -1914,8 +1899,6 @@ static asdl_seq*
 dotted_as_names_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, dotted_as_names_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.dotted_as_name+
         asdl_seq * a;
@@ -1933,7 +1916,6 @@ dotted_as_names_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, dotted_as_names_type, res);
     return res;
 }
 
@@ -1942,8 +1924,6 @@ static alias_ty
 dotted_as_name_rule(Parser *p)
 {
     alias_ty res = NULL;
-    if (is_memoized(p, dotted_as_name_type, &res))
-        return res;
     int mark = p->mark;
     { // dotted_name ['as' NAME]
         expr_ty a;
@@ -1964,7 +1944,6 @@ dotted_as_name_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, dotted_as_name_type, res);
     return res;
 }
 
@@ -2565,8 +2544,6 @@ static withitem_ty
 with_item_rule(Parser *p)
 {
     withitem_ty res = NULL;
-    if (is_memoized(p, with_item_type, &res))
-        return res;
     int mark = p->mark;
     { // expression ['as' target]
         expr_ty e;
@@ -2587,7 +2564,6 @@ with_item_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, with_item_type, res);
     return res;
 }
 
@@ -2795,8 +2771,6 @@ static stmt_ty
 return_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, return_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2832,7 +2806,6 @@ return_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, return_stmt_type, res);
     return res;
 }
 
@@ -3062,8 +3035,6 @@ static arguments_ty
 parameters_rule(Parser *p)
 {
     arguments_ty res = NULL;
-    if (is_memoized(p, parameters_type, &res))
-        return res;
     int mark = p->mark;
     { // slash_without_default [',' plain_names] [',' names_with_default] [',' star_etc?]
         asdl_seq* a;
@@ -3161,7 +3132,6 @@ parameters_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, parameters_type, res);
     return res;
 }
 
@@ -3170,8 +3140,6 @@ static asdl_seq*
 slash_without_default_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, slash_without_default_type, &res))
-        return res;
     int mark = p->mark;
     { // plain_names ',' '/'
         asdl_seq* a;
@@ -3195,7 +3163,6 @@ slash_without_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, slash_without_default_type, res);
     return res;
 }
 
@@ -3204,8 +3171,6 @@ static SlashWithDefault*
 slash_with_default_rule(Parser *p)
 {
     SlashWithDefault* res = NULL;
-    if (is_memoized(p, slash_with_default_type, &res))
-        return res;
     int mark = p->mark;
     { // [plain_names ','] names_with_default ',' '/'
         void *a;
@@ -3232,7 +3197,6 @@ slash_with_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, slash_with_default_type, res);
     return res;
 }
 
@@ -3244,8 +3208,6 @@ static StarEtc*
 star_etc_rule(Parser *p)
 {
     StarEtc* res = NULL;
-    if (is_memoized(p, star_etc_type, &res))
-        return res;
     int mark = p->mark;
     { // '*' plain_name name_with_optional_default* [',' kwds] ','?
         arg_ty a;
@@ -3315,7 +3277,6 @@ star_etc_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_etc_type, res);
     return res;
 }
 
@@ -3324,8 +3285,6 @@ static NameDefaultPair*
 name_with_optional_default_rule(Parser *p)
 {
     NameDefaultPair* res = NULL;
-    if (is_memoized(p, name_with_optional_default_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' plain_name ['=' expression]
         arg_ty a;
@@ -3349,7 +3308,6 @@ name_with_optional_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, name_with_optional_default_type, res);
     return res;
 }
 
@@ -3358,8 +3316,6 @@ static asdl_seq*
 names_with_default_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, names_with_default_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.name_with_default+
         asdl_seq * a;
@@ -3377,7 +3333,6 @@ names_with_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, names_with_default_type, res);
     return res;
 }
 
@@ -3386,8 +3341,6 @@ static NameDefaultPair*
 name_with_default_rule(Parser *p)
 {
     NameDefaultPair* res = NULL;
-    if (is_memoized(p, name_with_default_type, &res))
-        return res;
     int mark = p->mark;
     { // plain_name '=' expression
         expr_ty e;
@@ -3411,7 +3364,6 @@ name_with_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, name_with_default_type, res);
     return res;
 }
 
@@ -3420,8 +3372,6 @@ static asdl_seq*
 plain_names_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, plain_names_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.(plain_name !'=')+
         asdl_seq * a;
@@ -3439,7 +3389,6 @@ plain_names_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, plain_names_type, res);
     return res;
 }
 
@@ -3448,8 +3397,6 @@ static arg_ty
 plain_name_rule(Parser *p)
 {
     arg_ty res = NULL;
-    if (is_memoized(p, plain_name_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3485,7 +3432,6 @@ plain_name_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, plain_name_type, res);
     return res;
 }
 
@@ -3494,8 +3440,6 @@ static arg_ty
 kwds_rule(Parser *p)
 {
     arg_ty res = NULL;
-    if (is_memoized(p, kwds_type, &res))
-        return res;
     int mark = p->mark;
     { // '**' plain_name
         arg_ty a;
@@ -3516,7 +3460,6 @@ kwds_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, kwds_type, res);
     return res;
 }
 
@@ -3525,8 +3468,6 @@ static expr_ty
 annotation_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, annotation_type, &res))
-        return res;
     int mark = p->mark;
     { // expression
         expr_ty expression_var;
@@ -3541,7 +3482,6 @@ annotation_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, annotation_type, res);
     return res;
 }
 
@@ -3666,8 +3606,6 @@ static asdl_seq*
 block_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, block_type, &res))
-        return res;
     int mark = p->mark;
     { // NEWLINE INDENT statements DEDENT
         asdl_seq* a;
@@ -3705,7 +3643,6 @@ block_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, block_type, res);
     return res;
 }
 
@@ -3714,8 +3651,6 @@ static asdl_seq*
 expressions_list_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, expressions_list_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.star_expression+ ','?
         asdl_seq * a;
@@ -3736,7 +3671,6 @@ expressions_list_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, expressions_list_type, res);
     return res;
 }
 
@@ -3748,8 +3682,6 @@ static expr_ty
 expressions_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, expressions_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3824,7 +3756,6 @@ expressions_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, expressions_type, res);
     return res;
 }
 
@@ -3833,8 +3764,6 @@ static expr_ty
 star_expression_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, star_expression_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3881,7 +3810,6 @@ star_expression_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_expression_type, res);
     return res;
 }
 
@@ -3890,8 +3818,6 @@ static asdl_seq*
 star_named_expressions_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, star_named_expressions_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.star_named_expression+ ','?
         asdl_seq * a;
@@ -3912,7 +3838,6 @@ star_named_expressions_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_named_expressions_type, res);
     return res;
 }
 
@@ -3921,8 +3846,6 @@ static expr_ty
 star_named_expression_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, star_named_expression_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3969,7 +3892,6 @@ star_named_expression_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_named_expression_type, res);
     return res;
 }
 
@@ -3978,8 +3900,6 @@ static expr_ty
 named_expression_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, named_expression_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4029,7 +3949,6 @@ named_expression_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, named_expression_type, res);
     return res;
 }
 
@@ -4038,8 +3957,6 @@ static expr_ty
 annotated_rhs_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, annotated_rhs_type, &res))
-        return res;
     int mark = p->mark;
     { // yield_expr
         expr_ty yield_expr_var;
@@ -4065,7 +3982,6 @@ annotated_rhs_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, annotated_rhs_type, res);
     return res;
 }
 
@@ -4074,8 +3990,6 @@ static expr_ty
 expression_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, expression_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4142,7 +4056,6 @@ expression_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, expression_type, res);
     return res;
 }
 
@@ -4151,8 +4064,6 @@ static expr_ty
 lambdef_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, lambdef_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4194,7 +4105,6 @@ lambdef_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambdef_type, res);
     return res;
 }
 
@@ -4208,8 +4118,6 @@ static arguments_ty
 lambda_parameters_rule(Parser *p)
 {
     arguments_ty res = NULL;
-    if (is_memoized(p, lambda_parameters_type, &res))
-        return res;
     int mark = p->mark;
     { // lambda_slash_without_default [',' lambda_plain_names] [',' lambda_names_with_default] [',' lambda_star_etc?]
         asdl_seq* a;
@@ -4307,7 +4215,6 @@ lambda_parameters_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_parameters_type, res);
     return res;
 }
 
@@ -4316,8 +4223,6 @@ static asdl_seq*
 lambda_slash_without_default_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, lambda_slash_without_default_type, &res))
-        return res;
     int mark = p->mark;
     { // lambda_plain_names ',' '/'
         asdl_seq* a;
@@ -4341,7 +4246,6 @@ lambda_slash_without_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_slash_without_default_type, res);
     return res;
 }
 
@@ -4350,8 +4254,6 @@ static SlashWithDefault*
 lambda_slash_with_default_rule(Parser *p)
 {
     SlashWithDefault* res = NULL;
-    if (is_memoized(p, lambda_slash_with_default_type, &res))
-        return res;
     int mark = p->mark;
     { // [lambda_plain_names ','] lambda_names_with_default ',' '/'
         void *a;
@@ -4378,7 +4280,6 @@ lambda_slash_with_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_slash_with_default_type, res);
     return res;
 }
 
@@ -4390,8 +4291,6 @@ static StarEtc*
 lambda_star_etc_rule(Parser *p)
 {
     StarEtc* res = NULL;
-    if (is_memoized(p, lambda_star_etc_type, &res))
-        return res;
     int mark = p->mark;
     { // '*' lambda_plain_name lambda_name_with_optional_default* [',' lambda_kwds] ','?
         arg_ty a;
@@ -4461,7 +4360,6 @@ lambda_star_etc_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_star_etc_type, res);
     return res;
 }
 
@@ -4470,8 +4368,6 @@ static NameDefaultPair*
 lambda_name_with_optional_default_rule(Parser *p)
 {
     NameDefaultPair* res = NULL;
-    if (is_memoized(p, lambda_name_with_optional_default_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_plain_name ['=' expression]
         arg_ty a;
@@ -4495,7 +4391,6 @@ lambda_name_with_optional_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_name_with_optional_default_type, res);
     return res;
 }
 
@@ -4504,8 +4399,6 @@ static asdl_seq*
 lambda_names_with_default_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, lambda_names_with_default_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.lambda_name_with_default+
         asdl_seq * a;
@@ -4523,7 +4416,6 @@ lambda_names_with_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_names_with_default_type, res);
     return res;
 }
 
@@ -4532,8 +4424,6 @@ static NameDefaultPair*
 lambda_name_with_default_rule(Parser *p)
 {
     NameDefaultPair* res = NULL;
-    if (is_memoized(p, lambda_name_with_default_type, &res))
-        return res;
     int mark = p->mark;
     { // lambda_plain_name '=' expression
         expr_ty e;
@@ -4557,7 +4447,6 @@ lambda_name_with_default_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_name_with_default_type, res);
     return res;
 }
 
@@ -4566,8 +4455,6 @@ static asdl_seq*
 lambda_plain_names_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, lambda_plain_names_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.(lambda_plain_name !'=')+
         asdl_seq * a;
@@ -4585,7 +4472,6 @@ lambda_plain_names_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_plain_names_type, res);
     return res;
 }
 
@@ -4594,8 +4480,6 @@ static arg_ty
 lambda_plain_name_rule(Parser *p)
 {
     arg_ty res = NULL;
-    if (is_memoized(p, lambda_plain_name_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4628,7 +4512,6 @@ lambda_plain_name_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_plain_name_type, res);
     return res;
 }
 
@@ -4637,8 +4520,6 @@ static arg_ty
 lambda_kwds_rule(Parser *p)
 {
     arg_ty res = NULL;
-    if (is_memoized(p, lambda_kwds_type, &res))
-        return res;
     int mark = p->mark;
     { // '**' lambda_plain_name
         arg_ty a;
@@ -4659,7 +4540,6 @@ lambda_kwds_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lambda_kwds_type, res);
     return res;
 }
 
@@ -4668,8 +4548,6 @@ static expr_ty
 disjunction_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, disjunction_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4716,7 +4594,6 @@ disjunction_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, disjunction_type, res);
     return res;
 }
 
@@ -4725,8 +4602,6 @@ static expr_ty
 conjunction_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, conjunction_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4773,7 +4648,6 @@ conjunction_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, conjunction_type, res);
     return res;
 }
 
@@ -4782,8 +4656,6 @@ static expr_ty
 inversion_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, inversion_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4830,7 +4702,6 @@ inversion_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, inversion_type, res);
     return res;
 }
 
@@ -4839,8 +4710,6 @@ static expr_ty
 comparison_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, comparison_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4887,7 +4756,6 @@ comparison_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, comparison_type, res);
     return res;
 }
 
@@ -4906,8 +4774,6 @@ static CmpopExprPair*
 compare_op_bitwise_or_pair_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, compare_op_bitwise_or_pair_type, &res))
-        return res;
     int mark = p->mark;
     { // eq_bitwise_or
         CmpopExprPair* eq_bitwise_or_var;
@@ -5021,7 +4887,6 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, compare_op_bitwise_or_pair_type, res);
     return res;
 }
 
@@ -5030,8 +4895,6 @@ static CmpopExprPair*
 eq_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, eq_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // '==' bitwise_or
         expr_ty a;
@@ -5052,7 +4915,6 @@ eq_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, eq_bitwise_or_type, res);
     return res;
 }
 
@@ -5061,8 +4923,6 @@ static CmpopExprPair*
 noteq_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, noteq_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // '!=' bitwise_or
         expr_ty a;
@@ -5083,7 +4943,6 @@ noteq_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, noteq_bitwise_or_type, res);
     return res;
 }
 
@@ -5092,8 +4951,6 @@ static CmpopExprPair*
 lte_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, lte_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // '<=' bitwise_or
         expr_ty a;
@@ -5114,7 +4971,6 @@ lte_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lte_bitwise_or_type, res);
     return res;
 }
 
@@ -5123,8 +4979,6 @@ static CmpopExprPair*
 lt_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, lt_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // '<' bitwise_or
         expr_ty a;
@@ -5145,7 +4999,6 @@ lt_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, lt_bitwise_or_type, res);
     return res;
 }
 
@@ -5154,8 +5007,6 @@ static CmpopExprPair*
 gte_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, gte_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // '>=' bitwise_or
         expr_ty a;
@@ -5176,7 +5027,6 @@ gte_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, gte_bitwise_or_type, res);
     return res;
 }
 
@@ -5185,8 +5035,6 @@ static CmpopExprPair*
 gt_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, gt_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // '>' bitwise_or
         expr_ty a;
@@ -5207,7 +5055,6 @@ gt_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, gt_bitwise_or_type, res);
     return res;
 }
 
@@ -5216,8 +5063,6 @@ static CmpopExprPair*
 notin_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, notin_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // 'not' 'in' bitwise_or
         expr_ty a;
@@ -5241,7 +5086,6 @@ notin_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, notin_bitwise_or_type, res);
     return res;
 }
 
@@ -5250,8 +5094,6 @@ static CmpopExprPair*
 in_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, in_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // 'in' bitwise_or
         expr_ty a;
@@ -5272,7 +5114,6 @@ in_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, in_bitwise_or_type, res);
     return res;
 }
 
@@ -5281,8 +5122,6 @@ static CmpopExprPair*
 isnot_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, isnot_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // 'is' 'not' bitwise_or
         expr_ty a;
@@ -5306,7 +5145,6 @@ isnot_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, isnot_bitwise_or_type, res);
     return res;
 }
 
@@ -5315,8 +5153,6 @@ static CmpopExprPair*
 is_bitwise_or_rule(Parser *p)
 {
     CmpopExprPair* res = NULL;
-    if (is_memoized(p, is_bitwise_or_type, &res))
-        return res;
     int mark = p->mark;
     { // 'is' bitwise_or
         expr_ty a;
@@ -5337,7 +5173,6 @@ is_bitwise_or_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, is_bitwise_or_type, res);
     return res;
 }
 
@@ -6006,8 +5841,6 @@ static expr_ty
 factor_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, factor_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6104,7 +5937,6 @@ factor_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, factor_type, res);
     return res;
 }
 
@@ -6113,8 +5945,6 @@ static expr_ty
 power_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, power_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6164,7 +5994,6 @@ power_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, power_type, res);
     return res;
 }
 
@@ -6173,8 +6002,6 @@ static expr_ty
 await_primary_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, await_primary_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6221,7 +6048,6 @@ await_primary_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, await_primary_type, res);
     return res;
 }
 
@@ -6397,8 +6223,6 @@ static slice_ty
 slicing_rule(Parser *p)
 {
     slice_ty res = NULL;
-    if (is_memoized(p, slicing_type, &res))
-        return res;
     int mark = p->mark;
     { // '[' expression ']'
         expr_ty b;
@@ -6462,7 +6286,6 @@ slicing_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, slicing_type, res);
     return res;
 }
 
@@ -6471,8 +6294,6 @@ static slice_ty
 slice_expressions_rule(Parser *p)
 {
     slice_ty res = NULL;
-    if (is_memoized(p, slice_expressions_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6508,7 +6329,6 @@ slice_expressions_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, slice_expressions_type, res);
     return res;
 }
 
@@ -6517,8 +6337,6 @@ static slice_ty
 slices_rule(Parser *p)
 {
     slice_ty res = NULL;
-    if (is_memoized(p, slices_type, &res))
-        return res;
     int mark = p->mark;
     { // slice !','
         slice_ty a;
@@ -6555,7 +6373,6 @@ slices_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, slices_type, res);
     return res;
 }
 
@@ -6564,8 +6381,6 @@ static slice_ty
 slice_rule(Parser *p)
 {
     slice_ty res = NULL;
-    if (is_memoized(p, slice_type, &res))
-        return res;
     int mark = p->mark;
     { // expression? ':' expression? [':' expression?]
         void *a;
@@ -6606,7 +6421,6 @@ slice_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, slice_type, res);
     return res;
 }
 
@@ -6625,8 +6439,6 @@ static expr_ty
 atom_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, atom_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6802,7 +6614,6 @@ atom_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, atom_type, res);
     return res;
 }
 
@@ -6811,8 +6622,6 @@ static expr_ty
 list_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, list_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6851,7 +6660,6 @@ list_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, list_type, res);
     return res;
 }
 
@@ -6860,8 +6668,6 @@ static expr_ty
 listcomp_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, listcomp_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6903,7 +6709,6 @@ listcomp_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, listcomp_type, res);
     return res;
 }
 
@@ -6912,8 +6717,6 @@ static expr_ty
 tuple_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, tuple_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -6952,7 +6755,6 @@ tuple_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, tuple_type, res);
     return res;
 }
 
@@ -6961,8 +6763,6 @@ static expr_ty
 group_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, group_type, &res))
-        return res;
     int mark = p->mark;
     { // '(' (yield_expr | named_expression) ')'
         void *a;
@@ -6986,7 +6786,6 @@ group_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, group_type, res);
     return res;
 }
 
@@ -6995,8 +6794,6 @@ static expr_ty
 genexp_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, genexp_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7038,7 +6835,6 @@ genexp_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, genexp_type, res);
     return res;
 }
 
@@ -7047,8 +6843,6 @@ static expr_ty
 set_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, set_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7087,7 +6881,6 @@ set_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, set_type, res);
     return res;
 }
 
@@ -7096,8 +6889,6 @@ static expr_ty
 setcomp_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, setcomp_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7139,7 +6930,6 @@ setcomp_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, setcomp_type, res);
     return res;
 }
 
@@ -7148,8 +6938,6 @@ static expr_ty
 dict_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, dict_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7188,7 +6976,6 @@ dict_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, dict_type, res);
     return res;
 }
 
@@ -7197,8 +6984,6 @@ static expr_ty
 dictcomp_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, dictcomp_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7240,7 +7025,6 @@ dictcomp_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, dictcomp_type, res);
     return res;
 }
 
@@ -7249,8 +7033,6 @@ static asdl_seq*
 kvpairs_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, kvpairs_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.kvpair+ ','?
         asdl_seq * a;
@@ -7271,7 +7053,6 @@ kvpairs_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, kvpairs_type, res);
     return res;
 }
 
@@ -7280,8 +7061,6 @@ static KeyValuePair*
 kvpair_rule(Parser *p)
 {
     KeyValuePair* res = NULL;
-    if (is_memoized(p, kvpair_type, &res))
-        return res;
     int mark = p->mark;
     { // '**' bitwise_or
         expr_ty a;
@@ -7322,7 +7101,6 @@ kvpair_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, kvpair_type, res);
     return res;
 }
 
@@ -7331,8 +7109,6 @@ static asdl_seq*
 for_if_clauses_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, for_if_clauses_type, &res))
-        return res;
     int mark = p->mark;
     { // ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
         asdl_seq * a;
@@ -7350,7 +7126,6 @@ for_if_clauses_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, for_if_clauses_type, res);
     return res;
 }
 
@@ -7359,8 +7134,6 @@ static expr_ty
 yield_expr_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, yield_expr_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7424,7 +7197,6 @@ yield_expr_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, yield_expr_type, res);
     return res;
 }
 
@@ -7433,8 +7205,6 @@ static expr_ty
 arguments_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, arguments_type, &res))
-        return res;
     int mark = p->mark;
     { // args ','?
         expr_ty a;
@@ -7455,7 +7225,6 @@ arguments_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, arguments_type, res);
     return res;
 }
 
@@ -7464,8 +7233,6 @@ static expr_ty
 args_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, args_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7548,7 +7315,6 @@ args_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, args_type, res);
     return res;
 }
 
@@ -7557,8 +7323,6 @@ static asdl_seq*
 kwargs_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, kwargs_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.kwarg+
         asdl_seq * a;
@@ -7576,7 +7340,6 @@ kwargs_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, kwargs_type, res);
     return res;
 }
 
@@ -7585,8 +7348,6 @@ static expr_ty
 starred_expression_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, starred_expression_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7622,7 +7383,6 @@ starred_expression_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, starred_expression_type, res);
     return res;
 }
 
@@ -7631,8 +7391,6 @@ static KeywordOrStarred*
 kwarg_rule(Parser *p)
 {
     KeywordOrStarred* res = NULL;
-    if (is_memoized(p, kwarg_type, &res))
-        return res;
     int mark = p->mark;
     { // NAME '=' expression
         expr_ty a;
@@ -7687,7 +7445,6 @@ kwarg_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, kwarg_type, res);
     return res;
 }
 
@@ -7696,8 +7453,6 @@ static expr_ty
 star_targets_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, star_targets_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7752,7 +7507,6 @@ star_targets_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_targets_type, res);
     return res;
 }
 
@@ -7761,8 +7515,6 @@ static asdl_seq*
 star_targets_seq_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, star_targets_seq_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.star_target+ ','?
         asdl_seq * a;
@@ -7783,7 +7535,6 @@ star_targets_seq_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_targets_seq_type, res);
     return res;
 }
 
@@ -7796,8 +7547,6 @@ static expr_ty
 star_target_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, star_target_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -7901,7 +7650,6 @@ star_target_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_target_type, res);
     return res;
 }
 
@@ -7914,8 +7662,6 @@ static expr_ty
 star_atom_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, star_atom_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -8016,7 +7762,6 @@ star_atom_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, star_atom_type, res);
     return res;
 }
 
@@ -8028,8 +7773,6 @@ static expr_ty
 inside_paren_ann_assign_target_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, inside_paren_ann_assign_target_type, &res))
-        return res;
     int mark = p->mark;
     { // ann_assign_subscript_attribute_target
         expr_ty ann_assign_subscript_attribute_target_var;
@@ -8078,7 +7821,6 @@ inside_paren_ann_assign_target_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, inside_paren_ann_assign_target_type, res);
     return res;
 }
 
@@ -8089,8 +7831,6 @@ static expr_ty
 ann_assign_subscript_attribute_target_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, ann_assign_subscript_attribute_target_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -8158,7 +7898,6 @@ ann_assign_subscript_attribute_target_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, ann_assign_subscript_attribute_target_type, res);
     return res;
 }
 
@@ -8167,8 +7906,6 @@ static asdl_seq*
 del_targets_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, del_targets_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.del_target+ ','?
         asdl_seq * a;
@@ -8189,7 +7926,6 @@ del_targets_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, del_targets_type, res);
     return res;
 }
 
@@ -8201,8 +7937,6 @@ static expr_ty
 del_target_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, del_target_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -8281,7 +8015,6 @@ del_target_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, del_target_type, res);
     return res;
 }
 
@@ -8290,8 +8023,6 @@ static expr_ty
 del_t_atom_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, del_t_atom_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -8392,7 +8123,6 @@ del_t_atom_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, del_t_atom_type, res);
     return res;
 }
 
@@ -8401,8 +8131,6 @@ static asdl_seq*
 targets_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, targets_type, &res))
-        return res;
     int mark = p->mark;
     { // ','.target+ ','?
         asdl_seq * a;
@@ -8423,7 +8151,6 @@ targets_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, targets_type, res);
     return res;
 }
 
@@ -8432,8 +8159,6 @@ static expr_ty
 target_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, target_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -8512,7 +8237,6 @@ target_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, target_type, res);
     return res;
 }
 
@@ -8701,8 +8425,6 @@ static void *
 t_lookahead_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, t_lookahead_type, &res))
-        return res;
     int mark = p->mark;
     { // '('
         void *literal;
@@ -8739,7 +8461,6 @@ t_lookahead_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, t_lookahead_type, res);
     return res;
 }
 
@@ -8748,8 +8469,6 @@ static expr_ty
 t_atom_rule(Parser *p)
 {
     expr_ty res = NULL;
-    if (is_memoized(p, t_atom_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -8850,7 +8569,6 @@ t_atom_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, t_atom_type, res);
     return res;
 }
 

--- a/peg_parser/parse.c
+++ b/peg_parser/parse.c
@@ -80,7 +80,7 @@ KeywordToken *reserved_keywords[] = {
 #define import_from_as_name_type 1018
 #define dotted_as_names_type 1019
 #define dotted_as_name_type 1020
-#define dotted_name_type 1021
+#define dotted_name_type 1021  // Left-recursive
 #define if_stmt_type 1022
 #define elif_stmt_type 1023
 #define else_block_type 1024
@@ -144,16 +144,16 @@ KeywordToken *reserved_keywords[] = {
 #define in_bitwise_or_type 1082
 #define isnot_bitwise_or_type 1083
 #define is_bitwise_or_type 1084
-#define bitwise_or_type 1085
-#define bitwise_xor_type 1086
-#define bitwise_and_type 1087
-#define shift_expr_type 1088
-#define sum_type 1089
-#define term_type 1090
+#define bitwise_or_type 1085  // Left-recursive
+#define bitwise_xor_type 1086  // Left-recursive
+#define bitwise_and_type 1087  // Left-recursive
+#define shift_expr_type 1088  // Left-recursive
+#define sum_type 1089  // Left-recursive
+#define term_type 1090  // Left-recursive
 #define factor_type 1091
 #define power_type 1092
 #define await_primary_type 1093
-#define primary_type 1094
+#define primary_type 1094  // Left-recursive
 #define slicing_type 1095
 #define slice_expressions_type 1096
 #define slices_type 1097
@@ -188,7 +188,7 @@ KeywordToken *reserved_keywords[] = {
 #define del_t_atom_type 1126
 #define targets_type 1127
 #define target_type 1128
-#define t_primary_type 1129
+#define t_primary_type 1129  // Left-recursive
 #define t_lookahead_type 1130
 #define t_atom_type 1131
 #define _loop1_1_type 1132
@@ -1944,6 +1944,7 @@ dotted_as_name_rule(Parser *p)
     return res;
 }
 
+// Left-recursive
 // dotted_name: dotted_name '.' NAME | NAME
 static expr_ty dotted_name_raw(Parser *);
 static expr_ty
@@ -5173,6 +5174,7 @@ is_bitwise_or_rule(Parser *p)
     return res;
 }
 
+// Left-recursive
 // bitwise_or: bitwise_or '|' bitwise_xor | bitwise_xor
 static expr_ty bitwise_or_raw(Parser *);
 static expr_ty
@@ -5254,6 +5256,7 @@ bitwise_or_raw(Parser *p)
     return res;
 }
 
+// Left-recursive
 // bitwise_xor: bitwise_xor '^' bitwise_and | bitwise_and
 static expr_ty bitwise_xor_raw(Parser *);
 static expr_ty
@@ -5335,6 +5338,7 @@ bitwise_xor_raw(Parser *p)
     return res;
 }
 
+// Left-recursive
 // bitwise_and: bitwise_and '&' shift_expr | shift_expr
 static expr_ty bitwise_and_raw(Parser *);
 static expr_ty
@@ -5416,6 +5420,7 @@ bitwise_and_raw(Parser *p)
     return res;
 }
 
+// Left-recursive
 // shift_expr: shift_expr '<<' sum | shift_expr '>>' sum | sum
 static expr_ty shift_expr_raw(Parser *);
 static expr_ty
@@ -5525,6 +5530,7 @@ shift_expr_raw(Parser *p)
     return res;
 }
 
+// Left-recursive
 // sum: sum '+' term | sum '-' term | term
 static expr_ty sum_raw(Parser *);
 static expr_ty
@@ -5634,6 +5640,7 @@ sum_raw(Parser *p)
     return res;
 }
 
+// Left-recursive
 // term:
 //     | term '*' factor
 //     | term '/' factor
@@ -6048,6 +6055,7 @@ await_primary_rule(Parser *p)
     return res;
 }
 
+// Left-recursive
 // primary:
 //     | primary '.' NAME
 //     | primary genexp
@@ -8237,6 +8245,7 @@ target_rule(Parser *p)
     return res;
 }
 
+// Left-recursive
 // t_primary:
 //     | t_primary '.' NAME &t_lookahead
 //     | t_primary slicing &t_lookahead

--- a/peg_parser/parse.c
+++ b/peg_parser/parse.c
@@ -611,8 +611,6 @@ static asdl_seq*
 statements_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, statements_type, &res))
-        return res;
     int mark = p->mark;
     { // statement+
         asdl_seq * a;
@@ -630,7 +628,6 @@ statements_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, statements_type, res);
     return res;
 }
 
@@ -8577,8 +8574,6 @@ static asdl_seq *
 _loop1_1_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_1_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -8598,7 +8593,7 @@ _loop1_1_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_1");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -8627,8 +8622,6 @@ static asdl_seq *
 _loop0_3_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_3_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -8654,7 +8647,7 @@ _loop0_3_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_3");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -8679,8 +8672,6 @@ static asdl_seq *
 _gather_2_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_2_type, &res))
-        return res;
     int mark = p->mark;
     { // small_stmt _loop0_3
         stmt_ty elem;
@@ -8698,7 +8689,6 @@ _gather_2_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_2_type, res);
     return res;
 }
 
@@ -8707,8 +8697,6 @@ static void *
 _tmp_4_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_4_type, &res))
-        return res;
     int mark = p->mark;
     { // 'import'
         void *keyword;
@@ -8734,7 +8722,6 @@ _tmp_4_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_4_type, res);
     return res;
 }
 
@@ -8743,8 +8730,6 @@ static void *
 _tmp_5_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_5_type, &res))
-        return res;
     int mark = p->mark;
     { // 'def'
         void *keyword;
@@ -8781,7 +8766,6 @@ _tmp_5_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_5_type, res);
     return res;
 }
 
@@ -8790,8 +8774,6 @@ static void *
 _tmp_6_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_6_type, &res))
-        return res;
     int mark = p->mark;
     { // 'class'
         void *keyword;
@@ -8817,7 +8799,6 @@ _tmp_6_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_6_type, res);
     return res;
 }
 
@@ -8826,8 +8807,6 @@ static void *
 _tmp_7_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_7_type, &res))
-        return res;
     int mark = p->mark;
     { // 'with'
         void *keyword;
@@ -8853,7 +8832,6 @@ _tmp_7_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_7_type, res);
     return res;
 }
 
@@ -8862,8 +8840,6 @@ static void *
 _tmp_8_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_8_type, &res))
-        return res;
     int mark = p->mark;
     { // 'for'
         void *keyword;
@@ -8889,7 +8865,6 @@ _tmp_8_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_8_type, res);
     return res;
 }
 
@@ -8898,8 +8873,6 @@ static void *
 _tmp_9_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_9_type, &res))
-        return res;
     int mark = p->mark;
     { // '=' annotated_rhs
         expr_ty d;
@@ -8920,7 +8893,6 @@ _tmp_9_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_9_type, res);
     return res;
 }
 
@@ -8929,8 +8901,6 @@ static void *
 _tmp_10_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_10_type, &res))
-        return res;
     int mark = p->mark;
     { // '(' inside_paren_ann_assign_target ')'
         expr_ty b;
@@ -8965,7 +8935,6 @@ _tmp_10_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_10_type, res);
     return res;
 }
 
@@ -8974,8 +8943,6 @@ static void *
 _tmp_11_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_11_type, &res))
-        return res;
     int mark = p->mark;
     { // '=' annotated_rhs
         expr_ty d;
@@ -8996,7 +8963,6 @@ _tmp_11_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_11_type, res);
     return res;
 }
 
@@ -9005,8 +8971,6 @@ static asdl_seq *
 _loop1_12_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_12_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9026,7 +8990,7 @@ _loop1_12_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_12");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9055,8 +9019,6 @@ static void *
 _tmp_13_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_13_type, &res))
-        return res;
     int mark = p->mark;
     { // yield_expr
         expr_ty yield_expr_var;
@@ -9082,7 +9044,6 @@ _tmp_13_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_13_type, res);
     return res;
 }
 
@@ -9091,8 +9052,6 @@ static void *
 _tmp_14_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_14_type, &res))
-        return res;
     int mark = p->mark;
     { // yield_expr
         expr_ty yield_expr_var;
@@ -9118,7 +9077,6 @@ _tmp_14_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_14_type, res);
     return res;
 }
 
@@ -9127,8 +9085,6 @@ static asdl_seq *
 _loop0_16_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_16_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9154,7 +9110,7 @@ _loop0_16_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_16");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9179,8 +9135,6 @@ static asdl_seq *
 _gather_15_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_15_type, &res))
-        return res;
     int mark = p->mark;
     { // NAME _loop0_16
         expr_ty elem;
@@ -9198,7 +9152,6 @@ _gather_15_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_15_type, res);
     return res;
 }
 
@@ -9207,8 +9160,6 @@ static asdl_seq *
 _loop0_18_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_18_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9234,7 +9185,7 @@ _loop0_18_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_18");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9259,8 +9210,6 @@ static asdl_seq *
 _gather_17_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_17_type, &res))
-        return res;
     int mark = p->mark;
     { // NAME _loop0_18
         expr_ty elem;
@@ -9278,7 +9227,6 @@ _gather_17_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_17_type, res);
     return res;
 }
 
@@ -9287,8 +9235,6 @@ static void *
 _tmp_19_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_19_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' expression
         void *literal;
@@ -9309,7 +9255,6 @@ _tmp_19_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_19_type, res);
     return res;
 }
 
@@ -9318,8 +9263,6 @@ static asdl_seq *
 _loop0_20_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_20_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9339,7 +9282,7 @@ _loop0_20_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_20");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9364,8 +9307,6 @@ static asdl_seq *
 _loop1_21_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_21_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9385,7 +9326,7 @@ _loop1_21_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_21");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9414,8 +9355,6 @@ static asdl_seq *
 _loop0_23_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_23_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9441,7 +9380,7 @@ _loop0_23_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_23");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9466,8 +9405,6 @@ static asdl_seq *
 _gather_22_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_22_type, &res))
-        return res;
     int mark = p->mark;
     { // import_from_as_name _loop0_23
         alias_ty elem;
@@ -9485,7 +9422,6 @@ _gather_22_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_22_type, res);
     return res;
 }
 
@@ -9494,8 +9430,6 @@ static void *
 _tmp_24_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_24_type, &res))
-        return res;
     int mark = p->mark;
     { // 'as' NAME
         void *keyword;
@@ -9516,7 +9450,6 @@ _tmp_24_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_24_type, res);
     return res;
 }
 
@@ -9525,8 +9458,6 @@ static asdl_seq *
 _loop0_26_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_26_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9552,7 +9483,7 @@ _loop0_26_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_26");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9577,8 +9508,6 @@ static asdl_seq *
 _gather_25_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_25_type, &res))
-        return res;
     int mark = p->mark;
     { // dotted_as_name _loop0_26
         alias_ty elem;
@@ -9596,7 +9525,6 @@ _gather_25_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_25_type, res);
     return res;
 }
 
@@ -9605,8 +9533,6 @@ static void *
 _tmp_27_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_27_type, &res))
-        return res;
     int mark = p->mark;
     { // 'as' NAME
         void *keyword;
@@ -9627,7 +9553,6 @@ _tmp_27_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_27_type, res);
     return res;
 }
 
@@ -9636,8 +9561,6 @@ static asdl_seq *
 _loop0_29_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_29_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9663,7 +9586,7 @@ _loop0_29_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_29");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9688,8 +9611,6 @@ static asdl_seq *
 _gather_28_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_28_type, &res))
-        return res;
     int mark = p->mark;
     { // with_item _loop0_29
         withitem_ty elem;
@@ -9707,7 +9628,6 @@ _gather_28_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_28_type, res);
     return res;
 }
 
@@ -9716,8 +9636,6 @@ static asdl_seq *
 _loop0_31_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_31_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9743,7 +9661,7 @@ _loop0_31_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_31");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9768,8 +9686,6 @@ static asdl_seq *
 _gather_30_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_30_type, &res))
-        return res;
     int mark = p->mark;
     { // with_item _loop0_31
         withitem_ty elem;
@@ -9787,7 +9703,6 @@ _gather_30_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_30_type, res);
     return res;
 }
 
@@ -9796,8 +9711,6 @@ static asdl_seq *
 _loop0_33_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_33_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9823,7 +9736,7 @@ _loop0_33_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_33");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9848,8 +9761,6 @@ static asdl_seq *
 _gather_32_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_32_type, &res))
-        return res;
     int mark = p->mark;
     { // with_item _loop0_33
         withitem_ty elem;
@@ -9867,7 +9778,6 @@ _gather_32_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_32_type, res);
     return res;
 }
 
@@ -9876,8 +9786,6 @@ static asdl_seq *
 _loop0_35_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_35_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -9903,7 +9811,7 @@ _loop0_35_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_35");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -9928,8 +9836,6 @@ static asdl_seq *
 _gather_34_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_34_type, &res))
-        return res;
     int mark = p->mark;
     { // with_item _loop0_35
         withitem_ty elem;
@@ -9947,7 +9853,6 @@ _gather_34_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_34_type, res);
     return res;
 }
 
@@ -9956,8 +9861,6 @@ static void *
 _tmp_36_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_36_type, &res))
-        return res;
     int mark = p->mark;
     { // 'as' target
         void *keyword;
@@ -9978,7 +9881,6 @@ _tmp_36_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_36_type, res);
     return res;
 }
 
@@ -9987,8 +9889,6 @@ static asdl_seq *
 _loop1_37_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_37_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10008,7 +9908,7 @@ _loop1_37_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_37");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10037,8 +9937,6 @@ static void *
 _tmp_38_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_38_type, &res))
-        return res;
     int mark = p->mark;
     { // 'as' target
         void *keyword;
@@ -10059,7 +9957,6 @@ _tmp_38_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_38_type, res);
     return res;
 }
 
@@ -10068,8 +9965,6 @@ static void *
 _tmp_39_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_39_type, &res))
-        return res;
     int mark = p->mark;
     { // 'from' expression
         void *keyword;
@@ -10090,7 +9985,6 @@ _tmp_39_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_39_type, res);
     return res;
 }
 
@@ -10099,8 +9993,6 @@ static void *
 _tmp_40_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_40_type, &res))
-        return res;
     int mark = p->mark;
     { // '->' annotation
         void *literal;
@@ -10121,7 +10013,6 @@ _tmp_40_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_40_type, res);
     return res;
 }
 
@@ -10130,8 +10021,6 @@ static void *
 _tmp_41_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_41_type, &res))
-        return res;
     int mark = p->mark;
     { // '->' annotation
         void *literal;
@@ -10152,7 +10041,6 @@ _tmp_41_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_41_type, res);
     return res;
 }
 
@@ -10161,8 +10049,6 @@ static void *
 _tmp_42_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_42_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' plain_names
         void *literal;
@@ -10183,7 +10069,6 @@ _tmp_42_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_42_type, res);
     return res;
 }
 
@@ -10192,8 +10077,6 @@ static void *
 _tmp_43_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_43_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' names_with_default
         void *literal;
@@ -10214,7 +10097,6 @@ _tmp_43_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_43_type, res);
     return res;
 }
 
@@ -10223,8 +10105,6 @@ static void *
 _tmp_44_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_44_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' star_etc?
         void *literal;
@@ -10245,7 +10125,6 @@ _tmp_44_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_44_type, res);
     return res;
 }
 
@@ -10254,8 +10133,6 @@ static void *
 _tmp_45_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_45_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' names_with_default
         void *literal;
@@ -10276,7 +10153,6 @@ _tmp_45_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_45_type, res);
     return res;
 }
 
@@ -10285,8 +10161,6 @@ static void *
 _tmp_46_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_46_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' star_etc?
         void *literal;
@@ -10307,7 +10181,6 @@ _tmp_46_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_46_type, res);
     return res;
 }
 
@@ -10316,8 +10189,6 @@ static void *
 _tmp_47_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_47_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' names_with_default
         void *literal;
@@ -10338,7 +10209,6 @@ _tmp_47_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_47_type, res);
     return res;
 }
 
@@ -10347,8 +10217,6 @@ static void *
 _tmp_48_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_48_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' star_etc?
         void *literal;
@@ -10369,7 +10237,6 @@ _tmp_48_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_48_type, res);
     return res;
 }
 
@@ -10378,8 +10245,6 @@ static void *
 _tmp_49_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_49_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' star_etc?
         void *literal;
@@ -10400,7 +10265,6 @@ _tmp_49_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_49_type, res);
     return res;
 }
 
@@ -10409,8 +10273,6 @@ static void *
 _tmp_50_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_50_type, &res))
-        return res;
     int mark = p->mark;
     { // plain_names ','
         void *literal;
@@ -10431,7 +10293,6 @@ _tmp_50_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_50_type, res);
     return res;
 }
 
@@ -10440,8 +10301,6 @@ static asdl_seq *
 _loop0_51_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_51_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10461,7 +10320,7 @@ _loop0_51_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_51");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10486,8 +10345,6 @@ static void *
 _tmp_52_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_52_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' kwds
         arg_ty d;
@@ -10508,7 +10365,6 @@ _tmp_52_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_52_type, res);
     return res;
 }
 
@@ -10517,8 +10373,6 @@ static asdl_seq *
 _loop1_53_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_53_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10538,7 +10392,7 @@ _loop1_53_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_53");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10567,8 +10421,6 @@ static void *
 _tmp_54_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_54_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' kwds
         arg_ty d;
@@ -10589,7 +10441,6 @@ _tmp_54_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_54_type, res);
     return res;
 }
 
@@ -10598,8 +10449,6 @@ static void *
 _tmp_55_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_55_type, &res))
-        return res;
     int mark = p->mark;
     { // '=' expression
         expr_ty e;
@@ -10620,7 +10469,6 @@ _tmp_55_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_55_type, res);
     return res;
 }
 
@@ -10629,8 +10477,6 @@ static asdl_seq *
 _loop0_57_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_57_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10656,7 +10502,7 @@ _loop0_57_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_57");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10681,8 +10527,6 @@ static asdl_seq *
 _gather_56_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_56_type, &res))
-        return res;
     int mark = p->mark;
     { // name_with_default _loop0_57
         NameDefaultPair* elem;
@@ -10700,7 +10544,6 @@ _gather_56_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_56_type, res);
     return res;
 }
 
@@ -10709,8 +10552,6 @@ static asdl_seq *
 _loop0_59_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_59_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10736,7 +10577,7 @@ _loop0_59_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_59");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10761,8 +10602,6 @@ static asdl_seq *
 _gather_58_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_58_type, &res))
-        return res;
     int mark = p->mark;
     { // (plain_name !'=') _loop0_59
         void *elem;
@@ -10780,7 +10619,6 @@ _gather_58_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_58_type, res);
     return res;
 }
 
@@ -10789,8 +10627,6 @@ static void *
 _tmp_60_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_60_type, &res))
-        return res;
     int mark = p->mark;
     { // ':' annotation
         void *literal;
@@ -10811,7 +10647,6 @@ _tmp_60_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_60_type, res);
     return res;
 }
 
@@ -10820,8 +10655,6 @@ static asdl_seq *
 _loop1_61_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_61_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10841,7 +10674,7 @@ _loop1_61_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_61");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10870,8 +10703,6 @@ static void *
 _tmp_62_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_62_type, &res))
-        return res;
     int mark = p->mark;
     { // '(' arguments? ')'
         void *literal;
@@ -10895,7 +10726,6 @@ _tmp_62_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_62_type, res);
     return res;
 }
 
@@ -10904,8 +10734,6 @@ static asdl_seq *
 _loop0_64_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_64_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -10931,7 +10759,7 @@ _loop0_64_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_64");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -10956,8 +10784,6 @@ static asdl_seq *
 _gather_63_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_63_type, &res))
-        return res;
     int mark = p->mark;
     { // star_expression _loop0_64
         expr_ty elem;
@@ -10975,7 +10801,6 @@ _gather_63_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_63_type, res);
     return res;
 }
 
@@ -10984,8 +10809,6 @@ static asdl_seq *
 _loop1_65_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_65_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11005,7 +10828,7 @@ _loop1_65_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_65");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11034,8 +10857,6 @@ static asdl_seq *
 _loop0_67_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_67_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11061,7 +10882,7 @@ _loop0_67_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_67");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11086,8 +10907,6 @@ static asdl_seq *
 _gather_66_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_66_type, &res))
-        return res;
     int mark = p->mark;
     { // star_named_expression _loop0_67
         expr_ty elem;
@@ -11105,7 +10924,6 @@ _gather_66_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_66_type, res);
     return res;
 }
 
@@ -11114,8 +10932,6 @@ static void *
 _tmp_68_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_68_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_plain_names
         void *literal;
@@ -11136,7 +10952,6 @@ _tmp_68_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_68_type, res);
     return res;
 }
 
@@ -11145,8 +10960,6 @@ static void *
 _tmp_69_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_69_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_names_with_default
         void *literal;
@@ -11167,7 +10980,6 @@ _tmp_69_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_69_type, res);
     return res;
 }
 
@@ -11176,8 +10988,6 @@ static void *
 _tmp_70_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_70_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_star_etc?
         void *literal;
@@ -11198,7 +11008,6 @@ _tmp_70_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_70_type, res);
     return res;
 }
 
@@ -11207,8 +11016,6 @@ static void *
 _tmp_71_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_71_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_names_with_default
         void *literal;
@@ -11229,7 +11036,6 @@ _tmp_71_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_71_type, res);
     return res;
 }
 
@@ -11238,8 +11044,6 @@ static void *
 _tmp_72_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_72_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_star_etc?
         void *literal;
@@ -11260,7 +11064,6 @@ _tmp_72_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_72_type, res);
     return res;
 }
 
@@ -11269,8 +11072,6 @@ static void *
 _tmp_73_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_73_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_names_with_default
         void *literal;
@@ -11291,7 +11092,6 @@ _tmp_73_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_73_type, res);
     return res;
 }
 
@@ -11300,8 +11100,6 @@ static void *
 _tmp_74_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_74_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_star_etc?
         void *literal;
@@ -11322,7 +11120,6 @@ _tmp_74_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_74_type, res);
     return res;
 }
 
@@ -11331,8 +11128,6 @@ static void *
 _tmp_75_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_75_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_star_etc?
         void *literal;
@@ -11353,7 +11148,6 @@ _tmp_75_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_75_type, res);
     return res;
 }
 
@@ -11362,8 +11156,6 @@ static void *
 _tmp_76_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_76_type, &res))
-        return res;
     int mark = p->mark;
     { // lambda_plain_names ','
         void *literal;
@@ -11384,7 +11176,6 @@ _tmp_76_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_76_type, res);
     return res;
 }
 
@@ -11393,8 +11184,6 @@ static asdl_seq *
 _loop0_77_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_77_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11414,7 +11203,7 @@ _loop0_77_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_77");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11439,8 +11228,6 @@ static void *
 _tmp_78_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_78_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_kwds
         arg_ty d;
@@ -11461,7 +11248,6 @@ _tmp_78_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_78_type, res);
     return res;
 }
 
@@ -11470,8 +11256,6 @@ static asdl_seq *
 _loop1_79_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_79_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11491,7 +11275,7 @@ _loop1_79_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_79");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11520,8 +11304,6 @@ static void *
 _tmp_80_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_80_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' lambda_kwds
         arg_ty d;
@@ -11542,7 +11324,6 @@ _tmp_80_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_80_type, res);
     return res;
 }
 
@@ -11551,8 +11332,6 @@ static void *
 _tmp_81_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_81_type, &res))
-        return res;
     int mark = p->mark;
     { // '=' expression
         expr_ty e;
@@ -11573,7 +11352,6 @@ _tmp_81_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_81_type, res);
     return res;
 }
 
@@ -11582,8 +11360,6 @@ static asdl_seq *
 _loop0_83_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_83_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11609,7 +11385,7 @@ _loop0_83_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_83");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11634,8 +11410,6 @@ static asdl_seq *
 _gather_82_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_82_type, &res))
-        return res;
     int mark = p->mark;
     { // lambda_name_with_default _loop0_83
         NameDefaultPair* elem;
@@ -11653,7 +11427,6 @@ _gather_82_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_82_type, res);
     return res;
 }
 
@@ -11662,8 +11435,6 @@ static asdl_seq *
 _loop0_85_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_85_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11689,7 +11460,7 @@ _loop0_85_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_85");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11714,8 +11485,6 @@ static asdl_seq *
 _gather_84_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_84_type, &res))
-        return res;
     int mark = p->mark;
     { // (lambda_plain_name !'=') _loop0_85
         void *elem;
@@ -11733,7 +11502,6 @@ _gather_84_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_84_type, res);
     return res;
 }
 
@@ -11742,8 +11510,6 @@ static asdl_seq *
 _loop1_86_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_86_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11763,7 +11529,7 @@ _loop1_86_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_86");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11792,8 +11558,6 @@ static asdl_seq *
 _loop1_87_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_87_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11813,7 +11577,7 @@ _loop1_87_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_87");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11842,8 +11606,6 @@ static asdl_seq *
 _loop1_88_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_88_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11863,7 +11625,7 @@ _loop1_88_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_88");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11892,8 +11654,6 @@ static asdl_seq *
 _loop0_90_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_90_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11919,7 +11679,7 @@ _loop0_90_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_90");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -11944,8 +11704,6 @@ static asdl_seq *
 _gather_89_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_89_type, &res))
-        return res;
     int mark = p->mark;
     { // expression _loop0_90
         expr_ty elem;
@@ -11963,7 +11721,6 @@ _gather_89_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_89_type, res);
     return res;
 }
 
@@ -11972,8 +11729,6 @@ static asdl_seq *
 _loop0_92_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_92_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -11999,7 +11754,7 @@ _loop0_92_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_92");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12024,8 +11779,6 @@ static asdl_seq *
 _gather_91_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_91_type, &res))
-        return res;
     int mark = p->mark;
     { // slice _loop0_92
         slice_ty elem;
@@ -12043,7 +11796,6 @@ _gather_91_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_91_type, res);
     return res;
 }
 
@@ -12052,8 +11804,6 @@ static void *
 _tmp_93_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_93_type, &res))
-        return res;
     int mark = p->mark;
     { // ':' expression?
         void *d;
@@ -12074,7 +11824,6 @@ _tmp_93_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_93_type, res);
     return res;
 }
 
@@ -12083,8 +11832,6 @@ static asdl_seq *
 _loop1_94_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_94_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12104,7 +11851,7 @@ _loop1_94_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_94");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12133,8 +11880,6 @@ static void *
 _tmp_95_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_95_type, &res))
-        return res;
     int mark = p->mark;
     { // tuple
         expr_ty tuple_var;
@@ -12171,7 +11916,6 @@ _tmp_95_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_95_type, res);
     return res;
 }
 
@@ -12180,8 +11924,6 @@ static void *
 _tmp_96_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_96_type, &res))
-        return res;
     int mark = p->mark;
     { // list
         expr_ty list_var;
@@ -12207,7 +11949,6 @@ _tmp_96_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_96_type, res);
     return res;
 }
 
@@ -12216,8 +11957,6 @@ static void *
 _tmp_97_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_97_type, &res))
-        return res;
     int mark = p->mark;
     { // dict
         expr_ty dict_var;
@@ -12265,7 +12004,6 @@ _tmp_97_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_97_type, res);
     return res;
 }
 
@@ -12274,8 +12012,6 @@ static void *
 _tmp_98_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_98_type, &res))
-        return res;
     int mark = p->mark;
     { // star_named_expression ',' star_named_expressions?
         void *literal;
@@ -12299,7 +12035,6 @@ _tmp_98_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_98_type, res);
     return res;
 }
 
@@ -12308,8 +12043,6 @@ static void *
 _tmp_99_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_99_type, &res))
-        return res;
     int mark = p->mark;
     { // yield_expr
         expr_ty yield_expr_var;
@@ -12335,7 +12068,6 @@ _tmp_99_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_99_type, res);
     return res;
 }
 
@@ -12344,8 +12076,6 @@ static asdl_seq *
 _loop0_101_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_101_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12371,7 +12101,7 @@ _loop0_101_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_101");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12396,8 +12126,6 @@ static asdl_seq *
 _gather_100_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_100_type, &res))
-        return res;
     int mark = p->mark;
     { // kvpair _loop0_101
         KeyValuePair* elem;
@@ -12415,7 +12143,6 @@ _gather_100_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_100_type, res);
     return res;
 }
 
@@ -12424,8 +12151,6 @@ static asdl_seq *
 _loop1_102_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop1_102_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12445,7 +12170,7 @@ _loop1_102_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop1_102");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12474,8 +12199,6 @@ static void *
 _tmp_103_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_103_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' args
         expr_ty c;
@@ -12496,7 +12219,6 @@ _tmp_103_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_103_type, res);
     return res;
 }
 
@@ -12505,8 +12227,6 @@ static void *
 _tmp_104_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_104_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' args
         expr_ty c;
@@ -12527,7 +12247,6 @@ _tmp_104_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_104_type, res);
     return res;
 }
 
@@ -12536,8 +12255,6 @@ static asdl_seq *
 _loop0_106_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_106_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12563,7 +12280,7 @@ _loop0_106_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_106");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12588,8 +12305,6 @@ static asdl_seq *
 _gather_105_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_105_type, &res))
-        return res;
     int mark = p->mark;
     { // kwarg _loop0_106
         KeywordOrStarred* elem;
@@ -12607,7 +12322,6 @@ _gather_105_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_105_type, res);
     return res;
 }
 
@@ -12616,8 +12330,6 @@ static asdl_seq *
 _loop0_107_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_107_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12637,7 +12349,7 @@ _loop0_107_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_107");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12662,8 +12374,6 @@ static asdl_seq *
 _loop0_109_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_109_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12689,7 +12399,7 @@ _loop0_109_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_109");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12714,8 +12424,6 @@ static asdl_seq *
 _gather_108_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_108_type, &res))
-        return res;
     int mark = p->mark;
     { // star_target _loop0_109
         expr_ty elem;
@@ -12733,7 +12441,6 @@ _gather_108_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_108_type, res);
     return res;
 }
 
@@ -12742,8 +12449,6 @@ static asdl_seq *
 _loop0_111_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_111_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12769,7 +12474,7 @@ _loop0_111_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_111");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12794,8 +12499,6 @@ static asdl_seq *
 _gather_110_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_110_type, &res))
-        return res;
     int mark = p->mark;
     { // del_target _loop0_111
         expr_ty elem;
@@ -12813,7 +12516,6 @@ _gather_110_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_110_type, res);
     return res;
 }
 
@@ -12822,8 +12524,6 @@ static asdl_seq *
 _loop0_113_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_113_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -12849,7 +12549,7 @@ _loop0_113_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_113");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -12874,8 +12574,6 @@ static asdl_seq *
 _gather_112_rule(Parser *p)
 {
     asdl_seq * res = NULL;
-    if (is_memoized(p, _gather_112_type, &res))
-        return res;
     int mark = p->mark;
     { // target _loop0_113
         expr_ty elem;
@@ -12893,7 +12591,6 @@ _gather_112_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _gather_112_type, res);
     return res;
 }
 
@@ -12902,8 +12599,6 @@ static void *
 _tmp_114_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_114_type, &res))
-        return res;
     int mark = p->mark;
     { // star_targets '='
         void *literal;
@@ -12924,7 +12619,6 @@ _tmp_114_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_114_type, res);
     return res;
 }
 
@@ -12933,8 +12627,6 @@ static void *
 _tmp_115_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_115_type, &res))
-        return res;
     int mark = p->mark;
     { // '.'
         void *literal;
@@ -12960,7 +12652,6 @@ _tmp_115_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_115_type, res);
     return res;
 }
 
@@ -12969,8 +12660,6 @@ static void *
 _tmp_116_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_116_type, &res))
-        return res;
     int mark = p->mark;
     { // '.'
         void *literal;
@@ -12996,7 +12685,6 @@ _tmp_116_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_116_type, res);
     return res;
 }
 
@@ -13005,8 +12693,6 @@ static void *
 _tmp_117_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_117_type, &res))
-        return res;
     int mark = p->mark;
     { // plain_name !'='
         arg_ty plain_name_var;
@@ -13023,7 +12709,6 @@ _tmp_117_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_117_type, res);
     return res;
 }
 
@@ -13032,8 +12717,6 @@ static void *
 _tmp_118_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_118_type, &res))
-        return res;
     int mark = p->mark;
     { // '@' factor NEWLINE
         expr_ty f;
@@ -13057,7 +12740,6 @@ _tmp_118_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_118_type, res);
     return res;
 }
 
@@ -13066,8 +12748,6 @@ static void *
 _tmp_119_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_119_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' star_expression
         expr_ty c;
@@ -13088,7 +12768,6 @@ _tmp_119_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_119_type, res);
     return res;
 }
 
@@ -13097,8 +12776,6 @@ static void *
 _tmp_120_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_120_type, &res))
-        return res;
     int mark = p->mark;
     { // lambda_plain_name !'='
         arg_ty lambda_plain_name_var;
@@ -13115,7 +12792,6 @@ _tmp_120_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_120_type, res);
     return res;
 }
 
@@ -13124,8 +12800,6 @@ static void *
 _tmp_121_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_121_type, &res))
-        return res;
     int mark = p->mark;
     { // 'or' conjunction
         expr_ty c;
@@ -13146,7 +12820,6 @@ _tmp_121_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_121_type, res);
     return res;
 }
 
@@ -13155,8 +12828,6 @@ static void *
 _tmp_122_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_122_type, &res))
-        return res;
     int mark = p->mark;
     { // 'and' inversion
         expr_ty c;
@@ -13177,7 +12848,6 @@ _tmp_122_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_122_type, res);
     return res;
 }
 
@@ -13186,8 +12856,6 @@ static void *
 _tmp_123_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_123_type, &res))
-        return res;
     int mark = p->mark;
     { // ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
         expr_ty a;
@@ -13220,7 +12888,6 @@ _tmp_123_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_123_type, res);
     return res;
 }
 
@@ -13229,8 +12896,6 @@ static void *
 _tmp_124_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_124_type, &res))
-        return res;
     int mark = p->mark;
     { // ',' star_target
         expr_ty c;
@@ -13251,7 +12916,6 @@ _tmp_124_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_124_type, res);
     return res;
 }
 
@@ -13260,8 +12924,6 @@ static asdl_seq *
 _loop0_125_rule(Parser *p)
 {
     void *res = NULL;
-    if (is_memoized(p, _loop0_125_type, &res))
-        return res;
     int mark = p->mark;
     void **children = PyMem_Malloc(sizeof(void *));
     if (!children) {
@@ -13281,7 +12943,7 @@ _loop0_125_rule(Parser *p)
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
                 if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc _loop0_125");
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
                     return NULL;
                 }
             }
@@ -13306,8 +12968,6 @@ static void *
 _tmp_126_rule(Parser *p)
 {
     void * res = NULL;
-    if (is_memoized(p, _tmp_126_type, &res))
-        return res;
     int mark = p->mark;
     { // 'if' disjunction
         void *keyword;
@@ -13328,7 +12988,6 @@ _tmp_126_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, _tmp_126_type, res);
     return res;
 }
 

--- a/peg_parser/parse.c
+++ b/peg_parser/parse.c
@@ -583,8 +583,6 @@ static mod_ty
 start_rule(Parser *p)
 {
     mod_ty res = NULL;
-    if (is_memoized(p, start_type, &res))
-        return res;
     int mark = p->mark;
     { // statements? $
         void *a;
@@ -605,7 +603,6 @@ start_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, start_type, res);
     return res;
 }
 
@@ -642,8 +639,6 @@ static asdl_seq*
 statement_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, statement_type, &res))
-        return res;
     int mark = p->mark;
     { // compound_stmt
         stmt_ty a;
@@ -672,7 +667,6 @@ statement_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, statement_type, res);
     return res;
 }
 
@@ -681,8 +675,6 @@ static asdl_seq*
 simple_stmt_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, simple_stmt_type, &res))
-        return res;
     int mark = p->mark;
     { // small_stmt !';' NEWLINE
         stmt_ty a;
@@ -725,7 +717,6 @@ simple_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, simple_stmt_type, res);
     return res;
 }
 
@@ -747,8 +738,6 @@ static stmt_ty
 small_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, small_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -962,7 +951,6 @@ small_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, small_stmt_type, res);
     return res;
 }
 
@@ -978,8 +966,6 @@ static stmt_ty
 compound_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, compound_stmt_type, &res))
-        return res;
     int mark = p->mark;
     { // &('def' | '@' | ASYNC) function_def
         stmt_ty function_def_var;
@@ -1074,7 +1060,6 @@ compound_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, compound_stmt_type, res);
     return res;
 }
 
@@ -1432,8 +1417,6 @@ static stmt_ty
 global_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, global_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1469,7 +1452,6 @@ global_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, global_stmt_type, res);
     return res;
 }
 
@@ -1478,8 +1460,6 @@ static stmt_ty
 nonlocal_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, nonlocal_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1515,7 +1495,6 @@ nonlocal_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, nonlocal_stmt_type, res);
     return res;
 }
 
@@ -1524,8 +1503,6 @@ static stmt_ty
 yield_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, yield_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1558,7 +1535,6 @@ yield_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, yield_stmt_type, res);
     return res;
 }
 
@@ -1567,8 +1543,6 @@ static stmt_ty
 assert_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, assert_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1607,7 +1581,6 @@ assert_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, assert_stmt_type, res);
     return res;
 }
 
@@ -1616,8 +1589,6 @@ static stmt_ty
 del_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, del_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1653,7 +1624,6 @@ del_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, del_stmt_type, res);
     return res;
 }
 
@@ -1662,8 +1632,6 @@ static stmt_ty
 import_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, import_stmt_type, &res))
-        return res;
     int mark = p->mark;
     { // import_name
         stmt_ty import_name_var;
@@ -1689,7 +1657,6 @@ import_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, import_stmt_type, res);
     return res;
 }
 
@@ -1698,8 +1665,6 @@ static stmt_ty
 import_name_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, import_name_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1735,7 +1700,6 @@ import_name_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, import_name_type, res);
     return res;
 }
 
@@ -1746,8 +1710,6 @@ static stmt_ty
 import_from_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, import_from_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -1823,7 +1785,6 @@ import_from_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, import_from_type, res);
     return res;
 }
 
@@ -2080,8 +2041,6 @@ static stmt_ty
 if_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, if_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2160,7 +2119,6 @@ if_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, if_stmt_type, res);
     return res;
 }
 
@@ -2171,8 +2129,6 @@ static stmt_ty
 elif_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, elif_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2251,7 +2207,6 @@ elif_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, elif_stmt_type, res);
     return res;
 }
 
@@ -2260,8 +2215,6 @@ static asdl_seq*
 else_block_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, else_block_type, &res))
-        return res;
     int mark = p->mark;
     { // 'else' ':' block
         asdl_seq* b;
@@ -2285,7 +2238,6 @@ else_block_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, else_block_type, res);
     return res;
 }
 
@@ -2294,8 +2246,6 @@ static stmt_ty
 while_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, while_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2340,7 +2290,6 @@ while_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, while_stmt_type, res);
     return res;
 }
 
@@ -2351,8 +2300,6 @@ static stmt_ty
 for_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, for_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2446,7 +2393,6 @@ for_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, for_stmt_type, res);
     return res;
 }
 
@@ -2459,8 +2405,6 @@ static stmt_ty
 with_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, with_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2613,7 +2557,6 @@ with_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, with_stmt_type, res);
     return res;
 }
 
@@ -2655,8 +2598,6 @@ static stmt_ty
 try_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, try_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2735,7 +2676,6 @@ try_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, try_stmt_type, res);
     return res;
 }
 
@@ -2744,8 +2684,6 @@ static excepthandler_ty
 except_block_rule(Parser *p)
 {
     excepthandler_ty res = NULL;
-    if (is_memoized(p, except_block_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2818,7 +2756,6 @@ except_block_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, except_block_type, res);
     return res;
 }
 
@@ -2827,8 +2764,6 @@ static asdl_seq*
 finally_block_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, finally_block_type, &res))
-        return res;
     int mark = p->mark;
     { // 'finally' ':' block
         asdl_seq* a;
@@ -2852,7 +2787,6 @@ finally_block_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, finally_block_type, res);
     return res;
 }
 
@@ -2907,8 +2841,6 @@ static stmt_ty
 raise_stmt_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, raise_stmt_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -2969,7 +2901,6 @@ raise_stmt_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, raise_stmt_type, res);
     return res;
 }
 
@@ -2978,8 +2909,6 @@ static stmt_ty
 function_def_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, function_def_type, &res))
-        return res;
     int mark = p->mark;
     { // decorators function_def_raw
         asdl_seq* d;
@@ -3011,7 +2940,6 @@ function_def_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, function_def_type, res);
     return res;
 }
 
@@ -3022,8 +2950,6 @@ static stmt_ty
 function_def_raw_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, function_def_raw_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3123,7 +3049,6 @@ function_def_raw_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, function_def_raw_type, res);
     return res;
 }
 
@@ -3625,8 +3550,6 @@ static asdl_seq*
 decorators_rule(Parser *p)
 {
     asdl_seq* res = NULL;
-    if (is_memoized(p, decorators_type, &res))
-        return res;
     int mark = p->mark;
     { // (('@' factor NEWLINE))+
         asdl_seq * a;
@@ -3644,7 +3567,6 @@ decorators_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, decorators_type, res);
     return res;
 }
 
@@ -3653,8 +3575,6 @@ static stmt_ty
 class_def_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, class_def_type, &res))
-        return res;
     int mark = p->mark;
     { // decorators class_def_raw
         asdl_seq* a;
@@ -3686,7 +3606,6 @@ class_def_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, class_def_type, res);
     return res;
 }
 
@@ -3695,8 +3614,6 @@ static stmt_ty
 class_def_raw_rule(Parser *p)
 {
     stmt_ty res = NULL;
-    if (is_memoized(p, class_def_raw_type, &res))
-        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3741,7 +3658,6 @@ class_def_raw_rule(Parser *p)
     }
     res = NULL;
   done:
-    insert_memo(p, mark, class_def_raw_type, res);
     return res;
 }
 

--- a/peg_parser/parse.c
+++ b/peg_parser/parse.c
@@ -3373,6 +3373,8 @@ static asdl_seq*
 plain_names_rule(Parser *p)
 {
     asdl_seq* res = NULL;
+    if (is_memoized(p, plain_names_type, &res))
+        return res;
     int mark = p->mark;
     { // ','.(plain_name !'=')+
         asdl_seq * a;
@@ -3390,6 +3392,7 @@ plain_names_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, plain_names_type, res);
     return res;
 }
 
@@ -3607,6 +3610,8 @@ static asdl_seq*
 block_rule(Parser *p)
 {
     asdl_seq* res = NULL;
+    if (is_memoized(p, block_type, &res))
+        return res;
     int mark = p->mark;
     { // NEWLINE INDENT statements DEDENT
         asdl_seq* a;
@@ -3644,6 +3649,7 @@ block_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, block_type, res);
     return res;
 }
 
@@ -3765,6 +3771,8 @@ static expr_ty
 star_expression_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, star_expression_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -3811,6 +3819,7 @@ star_expression_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, star_expression_type, res);
     return res;
 }
 
@@ -3991,6 +4000,8 @@ static expr_ty
 expression_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, expression_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -4057,6 +4068,7 @@ expression_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, expression_type, res);
     return res;
 }
 
@@ -5857,6 +5869,8 @@ static expr_ty
 factor_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, factor_type, &res))
+        return res;
     int mark = p->mark;
     if (p->mark == p->fill && fill_token(p) < 0) {
         return NULL;
@@ -5953,6 +5967,7 @@ factor_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, factor_type, res);
     return res;
 }
 
@@ -7228,6 +7243,8 @@ static expr_ty
 arguments_rule(Parser *p)
 {
     expr_ty res = NULL;
+    if (is_memoized(p, arguments_type, &res))
+        return res;
     int mark = p->mark;
     { // args ','?
         expr_ty a;
@@ -7248,6 +7265,7 @@ arguments_rule(Parser *p)
     }
     res = NULL;
   done:
+    insert_memo(p, mark, arguments_type, res);
     return res;
 }
 

--- a/peg_parser/peg_extension.c
+++ b/peg_parser/peg_extension.c
@@ -90,9 +90,25 @@ error:
     return result;
 }
 
+static PyObject *
+reset()
+{
+    reset_statistics();
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+dump()
+{
+    dump_statistics();
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef ParseMethods[] = {
     {"parse_file", (PyCFunction)(void(*)(void))parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
     {"parse_string", (PyCFunction)(void(*)(void))parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
+    {"reset", reset, METH_NOARGS},
+    {"dump", dump, METH_NOARGS},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/peg_parser/peg_extension.c
+++ b/peg_parser/peg_extension.c
@@ -91,24 +91,47 @@ error:
 }
 
 static PyObject *
-reset()
+clear_memo_stats()
 {
-    reset_statistics();
+    clear_memo_statistics();
     Py_RETURN_NONE;
 }
 
 static PyObject *
-dump()
+get_memo_stats()
 {
-    dump_statistics();
+    return get_memo_statistics();
+}
+
+// TODO: Write to Python's sys.stdout instead of C's stdout.
+static PyObject *
+dump_memo_stats()
+{
+    PyObject *list = get_memo_statistics();
+    if (list == NULL) {
+        return NULL;
+    }
+    Py_ssize_t len = PyList_Size(list);
+    for (Py_ssize_t i = 0; i < len; i++) {
+        PyObject *value = PyList_GetItem(list, i);  // Borrowed reference.
+        long count = PyLong_AsLong(value);
+        if (count < 0) {
+            break;
+        }
+        if (count > 0) {
+            printf("%4ld %9ld\n", i, count);
+        }
+    }
+    Py_DECREF(list);
     Py_RETURN_NONE;
 }
 
 static PyMethodDef ParseMethods[] = {
     {"parse_file", (PyCFunction)(void(*)(void))parse_file, METH_VARARGS|METH_KEYWORDS, "Parse a file."},
     {"parse_string", (PyCFunction)(void(*)(void))parse_string, METH_VARARGS|METH_KEYWORDS, "Parse a string."},
-    {"reset", reset, METH_NOARGS},
-    {"dump", dump, METH_NOARGS},
+    {"clear_memo_stats", clear_memo_stats, METH_NOARGS},
+    {"dump_memo_stats", dump_memo_stats, METH_NOARGS},
+    {"get_memo_stats", get_memo_stats, METH_NOARGS},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/peg_parser/pegen.c
+++ b/peg_parser/pegen.c
@@ -243,7 +243,7 @@ fill_token(Parser *p)
 // The array counts the number of tokens skipped by memoization,
 // indexed by type.
 
-static const int NSTATISTICS = 2000;
+#define NSTATISTICS 2000
 static long memo_statistics[NSTATISTICS];
 
 void

--- a/peg_parser/pegen.c
+++ b/peg_parser/pegen.c
@@ -273,11 +273,11 @@ is_memoized(Parser *p, int type, void *pres)
 
     for (Memo *m = t->memo; m != NULL; m = m->next) {
         if (m->type == type) {
+            if (0 <= type && type < NSTATISTICS) {
+                statistics[type] += m->mark - p->mark;
+            }
             p->mark = m->mark;
             *(void **)(pres) = m->node;
-            if (0 <= type && type < NSTATISTICS) {
-                statistics[type]++;
-            }
             // fprintf(stderr, "%d < %d: memoized!\n", p->mark, p->fill);
             return 1;
         }

--- a/peg_parser/pegen.c
+++ b/peg_parser/pegen.c
@@ -239,6 +239,27 @@ fill_token(Parser *p)
     return 0;
 }
 
+static const int NSTATISTICS = 2000;
+static int statistics[NSTATISTICS];
+
+void
+reset_statistics()
+{
+    for (int i = 0; i < NSTATISTICS; i++) {
+        statistics[i] = 0;
+    }
+}
+
+void
+dump_statistics()
+{
+    for (int i = 0; i < NSTATISTICS; i++) {
+        if (statistics[i] > 0) {
+            printf("%4d  %9d\n", i, statistics[i]);
+        }
+    }
+}
+
 int  // bool
 is_memoized(Parser *p, int type, void *pres)
 {
@@ -254,6 +275,9 @@ is_memoized(Parser *p, int type, void *pres)
         if (m->type == type) {
             p->mark = m->mark;
             *(void **)(pres) = m->node;
+            if (0 <= type && type < NSTATISTICS) {
+                statistics[type]++;
+            }
             // fprintf(stderr, "%d < %d: memoized!\n", p->mark, p->fill);
             return 1;
         }

--- a/peg_parser/pegen.h
+++ b/peg_parser/pegen.h
@@ -8,6 +8,9 @@
 #include <pyarena.h>
 #include <setjmp.h>
 
+extern void reset_statistics(void);
+extern void dump_statistics(void);
+
 enum INPUT_MODE {
     FILE_INPUT,
     STRING_INPUT,

--- a/peg_parser/pegen.h
+++ b/peg_parser/pegen.h
@@ -8,9 +8,6 @@
 #include <pyarena.h>
 #include <setjmp.h>
 
-extern void reset_statistics(void);
-extern void dump_statistics(void);
-
 enum INPUT_MODE {
     FILE_INPUT,
     STRING_INPUT,
@@ -86,6 +83,9 @@ typedef struct {
 
 extern const int n_keyword_lists;
 extern KeywordToken *reserved_keywords[];
+
+void clear_memo_statistics(void);
+PyObject *get_memo_statistics(void);
 
 int insert_memo(Parser *p, int mark, int type, void *node);
 int update_memo(Parser *p, int mark, int type, void *node);

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -198,8 +198,9 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         if subheader:
             self.print(subheader)
         self._setup_keywords()
-        for i, rulename in enumerate(self.todo, 1000):
-            self.print(f"#define {rulename}_type {i}")
+        for i, (rulename, rule) in enumerate(self.todo.items(), 1000):
+            comment = "  // Left-recursive" if rule.left_recursive else ""
+            self.print(f"#define {rulename}_type {i}{comment}")
         self.print()
         for rulename, rule in self.todo.items():
             if rule.is_loop() or rule.is_gather():
@@ -214,6 +215,8 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             for rulename, rule in list(self.todo.items()):
                 del self.todo[rulename]
                 self.print()
+                if rule.left_recursive:
+                    self.print("// Left-recursive")
                 self.visit(rule)
         if self.skip_actions:
             mode = 0

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -311,8 +311,11 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.print(f"static {result_type}")
         self.print(f"{node.name}_raw(Parser *p)")
 
+    def _should_memoize(self, node):
+        return node.memo and not node.left_recursive
+
     def _handle_default_rule_body(self, node: Rule, rhs: Rhs, result_type: str) -> None:
-        memoize = node.nomemo and not node.left_recursive
+        memoize = self._should_memoize(node)
 
         with self.indent():
             self.print(f"{result_type} res = NULL;")
@@ -339,7 +342,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             self.print("return res;")
 
     def _handle_loop_rule_body(self, node: Rule, rhs: Rhs) -> None:
-        memoize = node.nomemo and not node.left_recursive
+        memoize = self._should_memoize(node)
         is_repeat1 = node.name.startswith("_loop1")
 
         with self.indent():

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -311,7 +311,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.print(f"static {result_type}")
         self.print(f"{node.name}_raw(Parser *p)")
 
-    def _should_memoize(self, node):
+    def _should_memoize(self, node: Rule) -> bool:
         return node.memo and not node.left_recursive
 
     def _handle_default_rule_body(self, node: Rule, rhs: Rhs, result_type: str) -> None:

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -309,7 +309,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.print(f"{node.name}_raw(Parser *p)")
 
     def _handle_default_rule_body(self, node: Rule, rhs: Rhs, result_type: str) -> None:
-        memoize = not node.left_recursive
+        memoize = not (node.nomemo or node.left_recursive)
 
         with self.indent():
             self.print(f"{result_type} res = NULL;")
@@ -336,7 +336,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             self.print("return res;")
 
     def _handle_loop_rule_body(self, node: Rule, rhs: Rhs) -> None:
-        memoize = not node.left_recursive
+        memoize = not (node.nomemo or node.left_recursive)
         is_repeat1 = node.name.startswith("_loop1")
 
         with self.indent():

--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -309,7 +309,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.print(f"{node.name}_raw(Parser *p)")
 
     def _handle_default_rule_body(self, node: Rule, rhs: Rhs, result_type: str) -> None:
-        memoize = not (node.nomemo or node.left_recursive)
+        memoize = node.nomemo and not node.left_recursive
 
         with self.indent():
             self.print(f"{result_type} res = NULL;")
@@ -336,7 +336,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             self.print("return res;")
 
     def _handle_loop_rule_body(self, node: Rule, rhs: Rhs) -> None:
-        memoize = not (node.nomemo or node.left_recursive)
+        memoize = node.nomemo and not node.left_recursive
         is_repeat1 = node.name.startswith("_loop1")
 
         with self.indent():

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -71,10 +71,11 @@ SIMPLE_STR = True
 
 
 class Rule:
-    def __init__(self, name: str, type: Optional[str], rhs: Rhs):
+    def __init__(self, name: str, type: Optional[str], rhs: Rhs, nomemo=None):
         self.name = name
         self.type = type
         self.rhs = rhs
+        self.nomemo = bool(nomemo)
         self.visited = False
         self.nullable = False
         self.left_recursive = False

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -71,11 +71,11 @@ SIMPLE_STR = True
 
 
 class Rule:
-    def __init__(self, name: str, type: Optional[str], rhs: Rhs, nomemo=None):
+    def __init__(self, name: str, type: Optional[str], rhs: Rhs, memo=None):
         self.name = name
         self.type = type
         self.rhs = rhs
-        self.nomemo = bool(nomemo)
+        self.memo = bool(memo)
         self.visited = False
         self.nullable = False
         self.left_recursive = False

--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -71,7 +71,7 @@ SIMPLE_STR = True
 
 
 class Rule:
-    def __init__(self, name: str, type: Optional[str], rhs: Rhs, memo=None):
+    def __init__(self, name: str, type: Optional[str], rhs: Rhs, memo: Optional[object] = None):
         self.name = name
         self.type = type
         self.rhs = rhs

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -100,7 +100,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def meta(self) -> Optional[MetaTuple]:
-        # meta: "@" NAME NEWLINE | "@" NAME '='? NAME NEWLINE | "@" NAME '='? STRING NEWLINE
+        # meta: "@" NAME NEWLINE | "@" NAME NAME NEWLINE | "@" NAME STRING NEWLINE
         mark = self.mark()
         cut = False
         if (
@@ -119,8 +119,6 @@ class GeneratedParser(Parser):
             and
             (a := self.name())
             and
-            (opt := self.expect('='),)
-            and
             (b := self.name())
             and
             (newline := self.expect('NEWLINE'))
@@ -133,8 +131,6 @@ class GeneratedParser(Parser):
             (literal := self.expect("@"))
             and
             (name := self.name())
-            and
-            (opt := self.expect('='),)
             and
             (string := self.string())
             and
@@ -189,7 +185,7 @@ class GeneratedParser(Parser):
             and
             (dedent := self.expect('DEDENT'))
         ):
-            return Rule ( rulename [ 0 ] , rulename [ 1 ] , Rhs ( alts . alts + more_alts . alts ) , nomemo = opt )
+            return Rule ( rulename [ 0 ] , rulename [ 1 ] , Rhs ( alts . alts + more_alts . alts ) , memo = opt )
         self.reset(mark)
         if cut: return None
         cut = False
@@ -208,7 +204,7 @@ class GeneratedParser(Parser):
             and
             (dedent := self.expect('DEDENT'))
         ):
-            return Rule ( rulename [ 0 ] , rulename [ 1 ] , more_alts , nomemo = opt )
+            return Rule ( rulename [ 0 ] , rulename [ 1 ] , more_alts , memo = opt )
         self.reset(mark)
         if cut: return None
         cut = False
@@ -223,7 +219,7 @@ class GeneratedParser(Parser):
             and
             (newline := self.expect('NEWLINE'))
         ):
-            return Rule ( rulename [ 0 ] , rulename [ 1 ] , alts , nomemo = opt )
+            return Rule ( rulename [ 0 ] , rulename [ 1 ] , alts , memo = opt )
         self.reset(mark)
         if cut: return None
         return None

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -165,13 +165,13 @@ class GeneratedParser(Parser):
 
     @memoize
     def rule(self) -> Optional[Rule]:
-        # rule: '~'? rulename ":" alts NEWLINE INDENT more_alts DEDENT | '~'? rulename ":" NEWLINE INDENT more_alts DEDENT | '~'? rulename ":" alts NEWLINE
+        # rule: rulename memoflag? ":" alts NEWLINE INDENT more_alts DEDENT | rulename memoflag? ":" NEWLINE INDENT more_alts DEDENT | rulename memoflag? ":" alts NEWLINE
         mark = self.mark()
         cut = False
         if (
-            (opt := self.expect('~'),)
-            and
             (rulename := self.rulename())
+            and
+            (opt := self.memoflag(),)
             and
             (literal := self.expect(":"))
             and
@@ -190,9 +190,9 @@ class GeneratedParser(Parser):
         if cut: return None
         cut = False
         if (
-            (opt := self.expect('~'),)
-            and
             (rulename := self.rulename())
+            and
+            (opt := self.memoflag(),)
             and
             (literal := self.expect(":"))
             and
@@ -209,9 +209,9 @@ class GeneratedParser(Parser):
         if cut: return None
         cut = False
         if (
-            (opt := self.expect('~'),)
-            and
             (rulename := self.rulename())
+            and
+            (opt := self.memoflag(),)
             and
             (literal := self.expect(":"))
             and
@@ -261,6 +261,23 @@ class GeneratedParser(Parser):
             (name := self.name())
         ):
             return ( name . string , None )
+        self.reset(mark)
+        if cut: return None
+        return None
+
+    @memoize
+    def memoflag(self) -> Optional[str]:
+        # memoflag: '(' 'memo' ')'
+        mark = self.mark()
+        cut = False
+        if (
+            (literal := self.expect('('))
+            and
+            (literal_1 := self.expect('memo'))
+            and
+            (literal_2 := self.expect(')'))
+        ):
+            return "memo"
         self.reset(mark)
         if cut: return None
         return None

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -100,7 +100,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def meta(self) -> Optional[MetaTuple]:
-        # meta: "@" NAME NEWLINE | "@" NAME NAME NEWLINE | "@" NAME STRING NEWLINE
+        # meta: "@" NAME NEWLINE | "@" NAME '='? NAME NEWLINE | "@" NAME '='? STRING NEWLINE
         mark = self.mark()
         cut = False
         if (
@@ -119,6 +119,8 @@ class GeneratedParser(Parser):
             and
             (a := self.name())
             and
+            (opt := self.expect('='),)
+            and
             (b := self.name())
             and
             (newline := self.expect('NEWLINE'))
@@ -131,6 +133,8 @@ class GeneratedParser(Parser):
             (literal := self.expect("@"))
             and
             (name := self.name())
+            and
+            (opt := self.expect('='),)
             and
             (string := self.string())
             and
@@ -165,10 +169,12 @@ class GeneratedParser(Parser):
 
     @memoize
     def rule(self) -> Optional[Rule]:
-        # rule: rulename ":" alts NEWLINE INDENT more_alts DEDENT | rulename ":" NEWLINE INDENT more_alts DEDENT | rulename ":" alts NEWLINE
+        # rule: '~'? rulename ":" alts NEWLINE INDENT more_alts DEDENT | '~'? rulename ":" NEWLINE INDENT more_alts DEDENT | '~'? rulename ":" alts NEWLINE
         mark = self.mark()
         cut = False
         if (
+            (opt := self.expect('~'),)
+            and
             (rulename := self.rulename())
             and
             (literal := self.expect(":"))
@@ -183,11 +189,13 @@ class GeneratedParser(Parser):
             and
             (dedent := self.expect('DEDENT'))
         ):
-            return Rule ( rulename [ 0 ] , rulename [ 1 ] , Rhs ( alts . alts + more_alts . alts ) )
+            return Rule ( rulename [ 0 ] , rulename [ 1 ] , Rhs ( alts . alts + more_alts . alts ) , nomemo = opt )
         self.reset(mark)
         if cut: return None
         cut = False
         if (
+            (opt := self.expect('~'),)
+            and
             (rulename := self.rulename())
             and
             (literal := self.expect(":"))
@@ -200,11 +208,13 @@ class GeneratedParser(Parser):
             and
             (dedent := self.expect('DEDENT'))
         ):
-            return Rule ( rulename [ 0 ] , rulename [ 1 ] , more_alts )
+            return Rule ( rulename [ 0 ] , rulename [ 1 ] , more_alts , nomemo = opt )
         self.reset(mark)
         if cut: return None
         cut = False
         if (
+            (opt := self.expect('~'),)
+            and
             (rulename := self.rulename())
             and
             (literal := self.expect(":"))
@@ -213,7 +223,7 @@ class GeneratedParser(Parser):
             and
             (newline := self.expect('NEWLINE'))
         ):
-            return Rule ( rulename [ 0 ] , rulename [ 1 ] , alts )
+            return Rule ( rulename [ 0 ] , rulename [ 1 ] , alts , nomemo = opt )
         self.reset(mark)
         if cut: return None
         return None

--- a/pegen/metagrammar.gram
+++ b/pegen/metagrammar.gram
@@ -49,14 +49,18 @@ rules[RuleList]:
     | rule { [rule] }
 
 rule[Rule]:
-    | '~'? rulename ":" alts NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), memo=opt) }
-    | '~'? rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts, memo=opt) }
-    | '~'? rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts, memo=opt) }
+    | rulename memoflag? ":" alts NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), memo=opt) }
+    | rulename memoflag? ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts, memo=opt) }
+    | rulename memoflag? ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts, memo=opt) }
 
 rulename[RuleName]:
-    | NAME '[' type=NAME '*' ']' {(name.string, type.string+"*")}
-    | NAME '[' type=NAME ']' {(name.string, type.string)}
-    | NAME {(name.string, None)}
+    | NAME '[' type=NAME '*' ']' { (name.string, type.string+"*") }
+    | NAME '[' type=NAME ']' { (name.string, type.string) }
+    | NAME { (name.string, None) }
+
+# In the future this may return something more complicated
+memoflag[str]:
+    | '(' 'memo' ')' { "memo" }
 
 alts[Rhs]:
     | alt "|" alts { Rhs([alt] + alts.alts)}

--- a/pegen/metagrammar.gram
+++ b/pegen/metagrammar.gram
@@ -41,17 +41,17 @@ metas[MetaList]:
 
 meta[MetaTuple]:
     | "@" NAME NEWLINE { (name.string, None) }
-    | "@" a=NAME ['='] b=NAME NEWLINE { (a.string, b.string) }
-    | "@" NAME ['='] STRING NEWLINE { (name.string, literal_eval(string.string)) }
+    | "@" a=NAME b=NAME NEWLINE { (a.string, b.string) }
+    | "@" NAME STRING NEWLINE { (name.string, literal_eval(string.string)) }
 
 rules[RuleList]:
     | rule rules { [rule] + rules }
     | rule { [rule] }
 
 rule[Rule]:
-    | '~'? rulename ":" alts NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), nomemo=opt) }
-    | '~'? rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts, nomemo=opt) }
-    | '~'? rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts, nomemo=opt) }
+    | '~'? rulename ":" alts NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), memo=opt) }
+    | '~'? rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts, memo=opt) }
+    | '~'? rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts, memo=opt) }
 
 rulename[RuleName]:
     | NAME '[' type=NAME '*' ']' {(name.string, type.string+"*")}

--- a/pegen/metagrammar.gram
+++ b/pegen/metagrammar.gram
@@ -41,17 +41,17 @@ metas[MetaList]:
 
 meta[MetaTuple]:
     | "@" NAME NEWLINE { (name.string, None) }
-    | "@" a=NAME b=NAME NEWLINE { (a.string, b.string) }
-    | "@" NAME STRING NEWLINE { (name.string, literal_eval(string.string)) }
+    | "@" a=NAME ['='] b=NAME NEWLINE { (a.string, b.string) }
+    | "@" NAME ['='] STRING NEWLINE { (name.string, literal_eval(string.string)) }
 
 rules[RuleList]:
     | rule rules { [rule] + rules }
     | rule { [rule] }
 
 rule[Rule]:
-    | rulename ":" alts NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts)) }
-    | rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts) }
-    | rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts) }
+    | '~'? rulename ":" alts NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), nomemo=opt) }
+    | '~'? rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts, nomemo=opt) }
+    | '~'? rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts, nomemo=opt) }
 
 rulename[RuleName]:
     | NAME '[' type=NAME '*' ']' {(name.string, type.string+"*")}

--- a/scripts/joinstats.py
+++ b/scripts/joinstats.py
@@ -13,28 +13,31 @@ import os
 import re
 import sys
 
+from typing import Dict
+
 reporoot = os.path.dirname(os.path.dirname(__file__))
 parse_c = os.path.join(reporoot, "peg_parser", "parse.c")
+
 
 class TypeMapper:
     """State used to map types to names."""
 
-    def __init__(self, filename):
-        self.table = {}
+    def __init__(self, filename: str) -> None:
+        self.table: Dict[int, str] = {}
         with open(filename) as f:
             for line in f:
-                ##if line.startswith("#def"): breakpoint()
-                if match := re.match(r"#define (\w+)_type (\d+)", line):
+                match = re.match(r"#define (\w+)_type (\d+)", line)
+                if match:
                     name, type = match.groups()
                     if "left" in line.lower():
                         name += " // Left-recursive"
                     self.table[int(type)] = name
 
-    def lookup(self, type):
+    def lookup(self, type: int) -> str:
         return self.table.get(type, str(type))
 
 
-def main():
+def main() -> None:
     mapper = TypeMapper(parse_c)
     table = []
     filename = sys.argv[1]

--- a/scripts/joinstats.py
+++ b/scripts/joinstats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3.8
+
+"""Produce a report about the most-memoable types.
+
+Reads a list of statistics from stdin.  Each line must be two numbers,
+being a type and a count.  We then read some other files and produce a
+list sorted by most frequent type.
+
+There should also be something to recognize left-recursive rules.
+"""
+
+import os
+import re
+import sys
+
+reporoot = os.path.dirname(os.path.dirname(__file__))
+parse_c = os.path.join(reporoot, "peg_parser", "parse.c")
+
+class TypeMapper:
+    """State used to map types to names."""
+
+    def __init__(self, filename):
+        self.table = {}
+        with open(filename) as f:
+            for line in f:
+                ##if line.startswith("#def"): breakpoint()
+                if match := re.match(r"#define (\w+)_type (\d+)", line):
+                    name, type = match.groups()
+                    if "left" in line.lower():
+                        name += " // Left-recursive"
+                    self.table[int(type)] = name
+
+    def lookup(self, type):
+        return self.table.get(type, str(type))
+
+
+def main():
+    mapper = TypeMapper(parse_c)
+    table = []
+    filename = sys.argv[1]
+    with open(filename) as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            # Extra fields ignored
+            if len(parts) < 2:
+                print(f"{lineno}: bad input ({line!r})")
+                continue
+            try:
+                type, count = map(int, parts[:2])
+            except ValueError as err:
+                print(f"{lineno}: non-integer input ({line!r})")
+                continue
+            table.append((type, count))
+    table.sort(key=lambda values: -values[1])
+    for type, count in table:
+        print(f"{type:4d} {count:9d} {mapper.lookup(type)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -134,7 +134,7 @@ def parse_directory(
             if not extension:
                 build_parser_and_generator(
                     grammar_file,
-                    "pegen/parse.c",
+                    "peg_parser/parse.c",
                     compile_extension=True,
                     skip_actions=skip_actions,
                 )
@@ -151,7 +151,7 @@ def parse_directory(
         print("A grammar file was not provided - attempting to use existing file...\n")
 
     try:
-        from pegen import parse
+        from peg_parser import parse
     except:
         print(
             "An existing parser was not found. Please run `make` or specify a grammar file with the `-g` flag.",

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -151,7 +151,7 @@ def parse_directory(
         print("A grammar file was not provided - attempting to use existing file...\n")
 
     try:
-        from peg_parser import parse
+        from peg_parser import parse  # type: ignore
     except:
         print(
             "An existing parser was not found. Please run `make` or specify a grammar file with the `-g` flag.",
@@ -219,10 +219,10 @@ def parse_directory(
         )
 
     # Dump memo stats to @data.
-    with open("@data", "w") as f:
+    with open("@data", "w") as datafile:
         for i, count in enumerate(parse.get_memo_stats()):
             if count:
-                f.write(f"{i:4d} {count:9d}\n")
+                datafile.write(f"{i:4d} {count:9d}\n")
 
     if short:
         print_memstats()

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -219,7 +219,7 @@ def parse_directory(
         )
 
     if short:
-        parse.dump()
+        parse.dump_memo_stats()
         print_memstats()
 
     if errors:

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -218,8 +218,13 @@ def parse_directory(
             f"or {total_bytes / total_seconds :,.0f} bytes/sec.",
         )
 
+    # Dump memo stats to @data.
+    with open("@data", "w") as f:
+        for i, count in enumerate(parse.get_memo_stats()):
+            if count:
+                f.write(f"{i:4d} {count:9d}\n")
+
     if short:
-        parse.dump_memo_stats()
         print_memstats()
 
     if errors:

--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -219,6 +219,7 @@ def parse_directory(
         )
 
     if short:
+        parse.dump()
         print_memstats()
 
     if errors:


### PR DESCRIPTION
Addresses https://github.com/gvanrossum/pegen/issues/220#issuecomment-604019170 

Memoization is expensive. In the C generator, we now disable it except for rules with the special marker `(memo)` after the rule name (and type, if present). By selectively turning on memoization for a handful of rules the parser becomes faster and uses less memory.

Notes:
- Left-recursive rules always use memoization, since the implementation of left-recursion depends on it.
- The marker syntax is extensible, in case we need more per-rule flags in the future.

This also adds instrumentation to the C support code to measure how much each rule uses memoization.

Finally, it fixes two lines in scripts/test_parse_directory.py that were still using pegen/ instead of peg_parser/ as the output directory.