### PR TITLE
Properly aggregate the result of looped nonterminals

### DIFF
--- a/story6/parser.py
+++ b/story6/parser.py
@@ -34,7 +34,7 @@ class Parser:
     def loop(self, nonempty, func, *args):
         mark = self.mark()
         nodes = []
-        while node := func(*args) is not None:
+        while (node := func(*args)) is not None:
             nodes.append(node)
         if len(nodes) >= nonempty:
             return nodes

--- a/story7/parser.py
+++ b/story7/parser.py
@@ -34,7 +34,7 @@ class Parser:
     def loop(self, nonempty, func, *args):
         mark = self.mark()
         nodes = []
-        while node := func(*args) is not None:
+        while (node := func(*args)) is not None:
             nodes.append(node)
         if len(nodes) >= nonempty:
             return nodes


### PR DESCRIPTION
While experimenting and torturing the code from story7 in several ways to try and hack together my own language without properly looking up on the theory, I noticed getting back strange representations for rules like `fulltext: WORD fulltext*`:
A string like `a b c d e f` would successfully parse, but only yield:

```
Node(start, [
  Node(expr, [
    Node(term, [
      Node(atom, [
        Node(fulltext, [
          'a',
          [True]
        ])
      ])
    ]),
    []
  ]),
  ''
])
```

instead of:

```
Node(start, [
  Node(expr, [
    Node(term, [
      Node(atom, [
        Node(fulltext, [
          'a',
          [
            Node(fulltext, [
              'b',
              [
                Node(fulltext, [
                  'c',
```
...and so on.

I managed to trace it back to the condition for `while` in `loop()` of `parser.py` (present in story6 and story7), where the walrus operator is not parenthesis, thus first checking whether `func(*args) is not None` and assigning that boolean to `node` instead of the other way around.